### PR TITLE
fix: arquivos de exportação padrão na pasta output/

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ Todas sao opcionais.
 - `WAIT_BETWEEN_SEARCHES_MS` (padrao: `5000`)
 - `PAGE_TIMEOUT_MS` (padrao: `10000`)
 - `MAX_PAGES_PER_KEYWORD` (padrao: `5`)
-- `OUTPUT_FILE` (padrao: `vagas_linkedin.xlsx`)
-- `PDF_FILE` (padrao: `vagas_linkedin.pdf`)
+- `OUTPUT_FILE` (padrao: `output/vagas_linkedin.xlsx`)
+- `PDF_FILE` (padrao: `output/vagas_linkedin.pdf`)
 - `SEARCH_LOCATION` (padrao: `Brasil`)
 - `SEARCH_GEO_ID` (padrao: `106057199`)
 - `SEARCH_LANGUAGE` (padrao: `pt`)
@@ -212,10 +212,10 @@ set SEARCH_KEYWORDS=UX Designer,UI Designer,Product Manager,Product Owner&& npm 
 
 ## Saida
 
-Arquivos gerados por padrao:
+Arquivos gerados por padrao (pasta `output/`):
 
-- `vagas_linkedin.xlsx`
-- `vagas_linkedin.pdf`
+- `output/vagas_linkedin.xlsx`
+- `output/vagas_linkedin.pdf`
 
 Colunas exportadas:
 

--- a/src/config.js
+++ b/src/config.js
@@ -64,8 +64,8 @@ export function getConfig() {
       width: parseNumber(process.env.VIEWPORT_WIDTH, 1280),
       height: parseNumber(process.env.VIEWPORT_HEIGHT, 800)
     },
-    outputFile: process.env.OUTPUT_FILE || "vagas_linkedin.xlsx",
-    pdfFile: process.env.PDF_FILE || "vagas_linkedin.pdf",
+    outputFile: process.env.OUTPUT_FILE || "output/vagas_linkedin.xlsx",
+    pdfFile: process.env.PDF_FILE || "output/vagas_linkedin.pdf",
     searchLocation: process.env.SEARCH_LOCATION || "Brasil",
     searchGeoId: process.env.SEARCH_GEO_ID || "106057199",
     searchLanguage: process.env.SEARCH_LANGUAGE || "pt",

--- a/src/exporter.js
+++ b/src/exporter.js
@@ -1,9 +1,18 @@
-import { createWriteStream } from "fs";
+import { createWriteStream, mkdirSync } from "fs";
+import { dirname } from "path";
 import PDFDocument from "pdfkit";
 import XLSX from "xlsx";
 import { logInfo } from "./logger.js";
 
+function ensureParentDir(filePath) {
+  const dir = dirname(filePath);
+  if (dir && dir !== ".") {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
 export function exportToExcel(rows, outputFile) {
+  ensureParentDir(outputFile);
   const worksheet = XLSX.utils.json_to_sheet(rows);
   const workbook = XLSX.utils.book_new();
   XLSX.utils.book_append_sheet(workbook, worksheet, "Vagas");
@@ -21,6 +30,7 @@ function cleanJobUrl(url) {
 }
 
 export function exportToPDF(rows, outputFile) {
+  ensureParentDir(outputFile);
   return new Promise((resolve, reject) => {
     const doc = new PDFDocument({ margin: 30, size: "A4", layout: "landscape" });
     const stream = createWriteStream(outputFile);


### PR DESCRIPTION
## Contexto
Sem `.env`, o scraper gravava XLSX/PDF na raiz do projeto, enquanto a API e o dashboard só leem arquivos em `output/`. Isso também afetava o scraper no Docker (volume montado em `./output`).

## O que mudou
- Padrão de `OUTPUT_FILE` e `PDF_FILE` alinhado com `.env.example` (`output/vagas_linkedin.xlsx` e `output/vagas_linkedin.pdf`).
- Criação automática da pasta pai antes de exportar (equivalente a `mkdir -p`).
- README atualizado (variáveis de ambiente e seção Saída).

## Observação para quem já usava o padrão antigo
Quem dependia dos arquivos na raiz pode definir `OUTPUT_FILE` / `PDF_FILE` manualmente ou mover os arquivos para `output/`.

Made with [Cursor](https://cursor.com)