### PR TITLE
fix: #36 adjust docker-compose paths and network connectivity

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: backend/Dockerfile
     container_name: vagas-backend
-    command: ["node", "backend/index.js"]
+    command: ["node", "backend/src/server.js"] 
     env_file:
       - ./backend/.env
     environment:
@@ -20,6 +20,7 @@ services:
       context: .
       dockerfile: frontend/Dockerfile
     container_name: vagas-frontend
+    command: npm run dev --workspace=frontend -- --host 0.0.0.0
     environment:
       - VITE_API_PROXY_TARGET=http://backend:3001
     ports:


### PR DESCRIPTION
📝 Resumo
Este PR corrige falhas críticas no docker-compose.yml que impediam a inicialização correta do backend e o acesso ao frontend via navegador na máquina hospedeira.

Alterações Realizadas
Backend: Corrigido o command para apontar para o ponto de entrada correto do servidor: de backend/index.js para backend/src/server.js. Isso alinha o container com a estrutura atual do projeto.

Frontend: Adicionado o parâmetro --host 0.0.0.0 ao comando de execução do Vite. Isso permite que o servidor aceite conexões externas ao container, possibilitando o acesso via localhost:5173.

Refatorado o comando para utilizar explicitamente o gerenciamento de workspaces (--workspace=frontend), garantindo que as dependências e o contexto de execução sejam respeitados corretamente.

🐛 Problemas Resolvidos (Issues)
Fecha #36  - Falha na inicialização e falta de acessibilidade externa via Docker Compose

🧪 Como testar?
Certifique-se de que não há containers antigos rodando: docker-compose down.

Suba o ambiente: docker-compose up --build.

Validar Backend: Verifique nos logs se o container vagas-backend iniciou sem erros de "file not found".

Validar Frontend: Acesse [http://localhost:5173](https://www.google.com/search?q=http://localhost:5173&authuser=1) no seu navegador e verifique se a aplicação carrega corretamente.