### PR TITLE
refactor(frontend): reorganiza fluxo de carregamento para evitar setState síncrono em effects

### DIFF
--- a/frontend/src/hooks/useJobsData.ts
+++ b/frontend/src/hooks/useJobsData.ts
@@ -54,15 +54,19 @@ export function useJobsData() {
     });
   }, [loadFiles]);
 
-  useEffect(() => {
+useEffect(() => {
+  async function handleLoadJobs() {
     if (selectedFile) {
-      loadJobs(selectedFile);
+      await loadJobs(selectedFile);
       return;
     }
 
     setJobs([]);
     setMeta(EMPTY_META);
-  }, [selectedFile, loadJobs]);
+  }
+
+  handleLoadJobs();
+}, [selectedFile, loadJobs]);
 
   const triggerScraper = useCallback(async () => {
     setScraping(true);


### PR DESCRIPTION
Ajusta carregamento assíncrono de vagas

O que foi feito
Reorganizado o fluxo de carregamento de vagas no hook useJobsData.
Removida a chamada que causava atualização de estado dentro do useEffect.
Adequação às regras do ESLint (react-hooks/set-state-in-effect).
Mantido o comportamento atual da aplicação durante o carregamento dos dados.
Motivação

O lint estava bloqueando o push devido à regra react-hooks/set-state-in-effect, que identifica atualizações de estado executadas diretamente dentro de efeitos, podendo causar renderizações em cascata e impactar a performance.