### PR TITLE
PAV-5: Login social Google (OAuth)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Regras do Projeto
+
+## Git
+
+- NUNCA faça commits automaticamente. Sempre pergunte ao usuario antes de commitar.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,6 +14,9 @@ SESSION_SECRET=
 # CORS / frontend access (separar por vírgula)
 CORS_ALLOWED_ORIGINS=
 
+# URL do frontend (usada para redirect pos-OAuth)
+FRONTEND_URL=http://localhost:5173
+
 # LinkedIn search filters (defaults)
 SEARCH_LOCATION=Brasil
 SEARCH_GEO_ID=106057199

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -1,6 +1,5 @@
 import { randomBytes } from "crypto";
 import { Request, Response } from "express";
-import { getIronSession } from "iron-session";
 import { z } from "zod";
 import {
   AuthCallbackParamsSchema,
@@ -9,40 +8,17 @@ import {
 
 import { AuthService } from "./auth.service.js";
 
-interface SessionData {
-  oauth_state?: string;
-  userId?: string;
-}
-
-const sessionOptions = {
-  password: process.env.SESSION_SECRET!,
-  cookieName: "vagas_session",
-
-  cookieOptions: {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    maxAge: 60 * 60 * 24 * 7,
-  },
-};
-
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   async getUrl(req: Request, res: Response) {
     try {
-      const session = await getIronSession<SessionData>(
-        req,
-        res,
-        sessionOptions,
-      );
-
       const provider = OAuthProviderSchema.parse(req.params.provider);
 
       const state = randomBytes(16).toString("hex");
 
-      session.oauth_state = state;
-
-      await session.save();
+      (req.session as any).oauth_state = state;
+      await req.session.save();
 
       const url = await this.authService.getAuthUrl(provider, state);
 
@@ -62,7 +38,7 @@ export class AuthController {
   }
 
   async callback(req: Request, res: Response) {
-    const session = await getIronSession<SessionData>(req, res, sessionOptions);
+    const frontendUrl = process.env.FRONTEND_URL || "http://localhost:5173";
 
     try {
       const callbackUrl = `${req.protocol}://${req.get("host")}${req.originalUrl}`;
@@ -74,42 +50,30 @@ export class AuthController {
         callbackUrl,
       });
 
-      if (!session.oauth_state) {
-        return res.status(400).json({
-          error: "OAuth state ausente",
-        });
+      const oauthState = (req.session as any).oauth_state;
+
+      if (!oauthState) {
+        return res.redirect(`${frontendUrl}/login?error=oauth_state_missing`);
       }
 
-      if (session.oauth_state !== params.state) {
-        return res.status(400).json({
-          error: "OAuth state inválido",
-        });
+      if (oauthState !== params.state) {
+        return res.redirect(`${frontendUrl}/login?error=oauth_state_invalid`);
       }
 
-      delete session.oauth_state;
-      await session.save();
+      delete (req.session as any).oauth_state;
 
       const result = await this.authService.handleCallback({
         ...params,
         callbackUrl,
       });
 
-      return res.json(result);
+      req.session.userId = result.session.userId;
+      await req.session.save();
+
+      return res.redirect(`${frontendUrl}/auth/callback`);
     } catch (error) {
       console.error("OAuth callback error:", error);
-
-      if (error instanceof z.ZodError) {
-        return res.status(400).json({
-          error: "Parâmetros de callback inválidos",
-          details: error.format(),
-        });
-      }
-
-      const message = error instanceof Error ? error.message : "Erro interno";
-
-      return res.status(500).json({
-        error: message,
-      });
+      return res.redirect(`${frontendUrl}/login?error=oauth_failed`);
     }
   }
 }

--- a/backend/tests/integration/routes/auth.routes.test.ts
+++ b/backend/tests/integration/routes/auth.routes.test.ts
@@ -181,13 +181,12 @@ describe("Integration - Auth Routes", () => {
   // ── GET /:provider/callback ───────────────────────────────────────────────
 
   describe("GET /:provider/callback", () => {
-    it("retorna 200 e dados do usuario em callback valido", async () => {
+    it("redireciona ao frontend em callback valido", async () => {
       const res = await request(app)
         .get(`${BASE}/github/callback?code=abc123&state=valid-state-abc123`)
-        .expect(200);
+        .expect(302);
 
-      expect(res.body).toHaveProperty("user");
-      expect(res.body.user).toHaveProperty("email", "user@example.com");
+      expect(res.headers.location).toContain("/auth/callback");
     });
 
     it("chama handleCallback com os params corretos", async () => {
@@ -208,18 +207,19 @@ describe("Integration - Auth Routes", () => {
       const session = {
         oauth_state: "valid-state-abc123",
         save: vi.fn().mockResolvedValue(undefined),
+        userId: undefined as string | undefined,
       };
       vi.mocked(getIronSession).mockResolvedValue(session as any);
 
       await request(app)
         .get(`${BASE}/github/callback?code=abc123&state=valid-state-abc123`)
-        .expect(200);
+        .expect(302);
 
       expect(session.oauth_state).toBeUndefined();
       expect(session.save).toHaveBeenCalled();
     });
 
-    it("retorna 400 quando oauth_state da sessao esta ausente", async () => {
+    it("redireciona ao login quando oauth_state da sessao esta ausente", async () => {
       vi.mocked(getIronSession).mockResolvedValue({
         oauth_state: undefined,
         save: vi.fn(),
@@ -227,12 +227,12 @@ describe("Integration - Auth Routes", () => {
 
       const res = await request(app)
         .get(`${BASE}/github/callback?code=abc123&state=valid-state-abc123`)
-        .expect(400);
+        .expect(302);
 
-      expect(res.body).toHaveProperty("error", "OAuth state ausente");
+      expect(res.headers.location).toContain("/login?error=oauth_state_missing");
     });
 
-    it("retorna 400 quando state do query nao confere com o da sessao", async () => {
+    it("redireciona ao login quando state do query nao confere com o da sessao", async () => {
       vi.mocked(getIronSession).mockResolvedValue({
         oauth_state: "outro-state",
         save: vi.fn(),
@@ -240,12 +240,12 @@ describe("Integration - Auth Routes", () => {
 
       const res = await request(app)
         .get(`${BASE}/github/callback?code=abc123&state=state-errado`)
-        .expect(400);
+        .expect(302);
 
-      expect(res.body).toHaveProperty("error", "OAuth state inválido");
+      expect(res.headers.location).toContain("/login?error=oauth_state_invalid");
     });
 
-    it("retorna 400 para provider invalido nos params (ZodError)", async () => {
+    it("redireciona ao login para provider invalido nos params", async () => {
       vi.mocked(getIronSession).mockResolvedValue({
         oauth_state: "valid-state-abc123",
         save: vi.fn(),
@@ -253,12 +253,12 @@ describe("Integration - Auth Routes", () => {
 
       const res = await request(app)
         .get(`${BASE}/twitter/callback?code=abc&state=valid-state-abc123`)
-        .expect(400);
+        .expect(302);
 
-      expect(res.body).toHaveProperty("error", "Parâmetros de callback inválidos");
+      expect(res.headers.location).toContain("/login?error=oauth_failed");
     });
 
-    it("retorna 400 quando code esta ausente (ZodError)", async () => {
+    it("redireciona ao login quando code esta ausente", async () => {
       vi.mocked(getIronSession).mockResolvedValue({
         oauth_state: "valid-state-abc123",
         save: vi.fn(),
@@ -266,21 +266,21 @@ describe("Integration - Auth Routes", () => {
 
       const res = await request(app)
         .get(`${BASE}/github/callback?state=valid-state-abc123`)
-        .expect(400);
+        .expect(302);
 
-      expect(res.body).toHaveProperty("error");
+      expect(res.headers.location).toContain("/login?error=oauth_failed");
     });
 
-    it("retorna 500 quando handleCallback lanca erro", async () => {
+    it("redireciona ao login quando handleCallback lanca erro", async () => {
       mockAuthService.handleCallback.mockRejectedValueOnce(
         new Error("upstream OAuth error"),
       );
 
       const res = await request(app)
         .get(`${BASE}/github/callback?code=abc123&state=valid-state-abc123`)
-        .expect(500);
+        .expect(302);
 
-      expect(res.body).toHaveProperty("error", "upstream OAuth error");
+      expect(res.headers.location).toContain("/login?error=oauth_failed");
     });
   });
 

--- a/backend/tests/unit/modules/auth/auth.controller.test.ts
+++ b/backend/tests/unit/modules/auth/auth.controller.test.ts
@@ -1,16 +1,8 @@
 import { Request, Response } from "express";
-import { getIronSession } from "iron-session";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
-import { AuthController } from "../../../../src/modules/auth/auth.controller"; // Ajuste o caminho se necessário
+import { AuthController } from "../../../../src/modules/auth/auth.controller";
 
-// Mock das dependências externas
-vi.mock("iron-session", () => ({
-  getIronSession: vi.fn(),
-}));
-
-// Mock dos Schemas do Zod para isolar o comportamento se necessário,
-// mas vamos garantir que os inputs passem por eles perfeitamente.
 vi.mock("../../../../src/types/auth.types.js", () => ({
   OAuthProviderSchema: {
     parse: vi.fn((val) => {
@@ -35,37 +27,37 @@ describe("AuthController", () => {
 
   beforeEach(() => {
     vi.stubEnv("SESSION_SECRET", "um-password-longo-com-mais-de-32-caracteres");
+    vi.stubEnv("FRONTEND_URL", "http://localhost:5173");
     vi.clearAllMocks();
 
-    // Mock do AuthService
     authServiceMock = {
       getAuthUrl: vi.fn().mockResolvedValue("https://provider.com/auth"),
       handleCallback: vi
         .fn()
-        .mockResolvedValue({ token: "jwt-token", user: { id: "1" } }),
+        .mockResolvedValue({ user: { id: "1" }, session: { userId: "1" } }),
     };
 
     authController = new AuthController(authServiceMock);
 
-    // Mock da Sessão do iron-session
     sessionMock = {
       save: vi.fn().mockResolvedValue(undefined),
       oauth_state: undefined,
+      userId: undefined,
     };
-    (getIronSession as any).mockResolvedValue(sessionMock);
 
-    // Mocks do Express Request e Response
     reqMock = {
       params: {},
       query: {},
       protocol: "http",
       get: vi.fn().mockReturnValue("localhost:3000"),
       originalUrl: "/auth/callback",
+      session: sessionMock,
     };
 
     resMock = {
       json: vi.fn().mockReturnThis(),
       status: vi.fn().mockReturnThis(),
+      redirect: vi.fn().mockReturnThis(),
     };
   });
 
@@ -100,14 +92,15 @@ describe("AuthController", () => {
   });
 
   describe("callback", () => {
-    it("deve processar o callback com sucesso quando o state for válido", async () => {
+    it("deve redirecionar ao frontend apos callback valido", async () => {
       sessionMock.oauth_state = "state_secreto_123";
       reqMock.params = { provider: "google" };
       reqMock.query = { code: "auth_code_abc", state: "state_secreto_123" };
 
       await authController.callback(reqMock as Request, resMock as Response);
 
-      expect(sessionMock.oauth_state).toBeUndefined(); // Deve deletar após o uso
+      expect(sessionMock.oauth_state).toBeUndefined();
+      expect(sessionMock.userId).toBe("1");
       expect(sessionMock.save).toHaveBeenCalled();
       expect(authServiceMock.handleCallback).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -117,39 +110,36 @@ describe("AuthController", () => {
           callbackUrl: "http://localhost:3000/auth/callback",
         }),
       );
-      expect(resMock.json).toHaveBeenCalledWith({
-        token: "jwt-token",
-        user: { id: "1" },
-      });
+      expect(resMock.redirect).toHaveBeenCalledWith(
+        "http://localhost:5173/auth/callback",
+      );
     });
 
-    it("deve retornar 400 se o oauth_state estiver ausente na sessão", async () => {
+    it("deve redirecionar ao login se o oauth_state estiver ausente na sessão", async () => {
       sessionMock.oauth_state = undefined;
       reqMock.params = { provider: "google" };
       reqMock.query = { code: "code", state: "any_state" };
 
       await authController.callback(reqMock as Request, resMock as Response);
 
-      expect(resMock.status).toHaveBeenCalledWith(400);
-      expect(resMock.json).toHaveBeenCalledWith({
-        error: "OAuth state ausente",
-      });
+      expect(resMock.redirect).toHaveBeenCalledWith(
+        "http://localhost:5173/login?error=oauth_state_missing",
+      );
     });
 
-    it("deve retornar 400 se o state da query for diferente do state da sessão", async () => {
+    it("deve redirecionar ao login se o state da query for diferente do state da sessão", async () => {
       sessionMock.oauth_state = "state_original";
       reqMock.params = { provider: "google" };
       reqMock.query = { code: "code", state: "state_ataque_csrf" };
 
       await authController.callback(reqMock as Request, resMock as Response);
 
-      expect(resMock.status).toHaveBeenCalledWith(400);
-      expect(resMock.json).toHaveBeenCalledWith({
-        error: "OAuth state inválido",
-      });
+      expect(resMock.redirect).toHaveBeenCalledWith(
+        "http://localhost:5173/login?error=oauth_state_invalid",
+      );
     });
 
-    it("deve retornar 500 se o serviço falhar", async () => {
+    it("deve redirecionar ao login com erro se o serviço falhar", async () => {
       sessionMock.oauth_state = "valid_state";
       reqMock.params = { provider: "google" };
       reqMock.query = { code: "code", state: "valid_state" };
@@ -160,10 +150,9 @@ describe("AuthController", () => {
 
       await authController.callback(reqMock as Request, resMock as Response);
 
-      expect(resMock.status).toHaveBeenCalledWith(500);
-      expect(resMock.json).toHaveBeenCalledWith({
-        error: "Falha na comunicação com o provedor",
-      });
+      expect(resMock.redirect).toHaveBeenCalledWith(
+        "http://localhost:5173/login?error=oauth_failed",
+      );
     });
   });
 });

--- a/docs/superpowers/plans/2026-06-14-google-oauth-integration.md
+++ b/docs/superpowers/plans/2026-06-14-google-oauth-integration.md
@@ -1,0 +1,319 @@
+# Google OAuth Integration - Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Integrate the existing Google OAuth backend with the frontend button so users can login with Google end-to-end.
+
+**Architecture:** Full Redirect flow — frontend redirects to Google, Google calls backend callback, backend saves session and redirects browser back to frontend. Frontend detects authenticated session and navigates to /app.
+
+**Tech Stack:** Express (backend), React + react-router-dom (frontend), iron-session (sessions), openid-client (OAuth)
+
+---
+
+## File Structure
+
+| Action | Path | Responsibility |
+|--------|------|---------------|
+| Modify | `backend/.env.example` | Add FRONTEND_URL variable |
+| Modify | `backend/src/modules/auth/auth.controller.ts` | Save session + redirect instead of JSON |
+| Modify | `frontend/src/services/authService.ts` | Add `getGoogleAuthUrl()` function |
+| Modify | `frontend/src/components/login/RigthSide.tsx` | Add onClick to Google button |
+| Modify | `frontend/src/components/login/RegisterSide.tsx` | Add onClick to Google button |
+| Create | `frontend/src/pages/auth/AuthCallback.tsx` | OAuth callback page |
+| Modify | `frontend/src/App.tsx` | Add /auth/callback route |
+
+---
+
+### Task 1: Backend — Add FRONTEND_URL env var
+
+**Files:**
+- Modify: `backend/.env.example:14-15`
+
+- [ ] **Step 1: Add FRONTEND_URL to .env.example**
+
+Add after the `CORS_ALLOWED_ORIGINS` line in `backend/.env.example`:
+
+```
+# URL do frontend (usada para redirect pos-OAuth)
+FRONTEND_URL=http://localhost:5173
+```
+
+- [ ] **Step 2: Add FRONTEND_URL to your local .env**
+
+Run: `grep FRONTEND_URL backend/.env || echo "FRONTEND_URL=http://localhost:5173" >> backend/.env`
+
+---
+
+### Task 2: Backend — Fix callback to save session and redirect
+
+**Files:**
+- Modify: `backend/src/modules/auth/auth.controller.ts:64-115`
+
+- [ ] **Step 1: Modify the callback method**
+
+Replace the entire `callback` method in `backend/src/modules/auth/auth.controller.ts` with:
+
+```typescript
+async callback(req: Request, res: Response) {
+  const session = await getIronSession<SessionData>(req, res, sessionOptions);
+  const frontendUrl = process.env.FRONTEND_URL || "http://localhost:5173";
+
+  try {
+    const callbackUrl = `${req.protocol}://${req.get("host")}${req.originalUrl}`;
+
+    const params = AuthCallbackParamsSchema.parse({
+      provider: req.params.provider,
+      code: req.query.code,
+      state: req.query.state,
+      callbackUrl,
+    });
+
+    if (!session.oauth_state) {
+      return res.redirect(`${frontendUrl}/login?error=oauth_state_missing`);
+    }
+
+    if (session.oauth_state !== params.state) {
+      return res.redirect(`${frontendUrl}/login?error=oauth_state_invalid`);
+    }
+
+    delete session.oauth_state;
+
+    const result = await this.authService.handleCallback({
+      ...params,
+      callbackUrl,
+    });
+
+    session.userId = result.session.userId;
+    await session.save();
+
+    return res.redirect(`${frontendUrl}/auth/callback`);
+  } catch (error) {
+    console.error("OAuth callback error:", error);
+    return res.redirect(`${frontendUrl}/login?error=oauth_failed`);
+  }
+}
+```
+
+- [ ] **Step 2: Verify backend compiles**
+
+Run: `cd backend && npx tsc --noEmit`
+Expected: No errors
+
+---
+
+### Task 3: Frontend — Add getGoogleAuthUrl to authService
+
+**Files:**
+- Modify: `frontend/src/services/authService.ts` (append at end)
+
+- [ ] **Step 1: Add the function**
+
+Append to `frontend/src/services/authService.ts`:
+
+```typescript
+export async function getGoogleAuthUrl(): Promise<string> {
+  const response = await fetch(buildUrl("/api/auth/google/url"), {
+    credentials: "include",
+  });
+
+  const payload = await parseResponse(response);
+
+  if (!response.ok) {
+    throw createError(payload, "Falha ao obter URL de autenticacao Google.");
+  }
+
+  return payload.url;
+}
+```
+
+---
+
+### Task 4: Frontend — Wire Google button onClick in RigthSide.tsx
+
+**Files:**
+- Modify: `frontend/src/components/login/RigthSide.tsx:2,221`
+
+- [ ] **Step 1: Add import**
+
+Add to the imports at the top of `frontend/src/components/login/RigthSide.tsx`:
+
+```typescript
+import { login, getGoogleAuthUrl } from "@/services/authService";
+```
+
+(Replace the existing `import { login } from "@/services/authService";` on line 2)
+
+- [ ] **Step 2: Add handler function**
+
+Inside `RightSide()`, after the existing state declarations (after line 56), add:
+
+```typescript
+const handleGoogleLogin = async () => {
+  setIsLoading(true);
+  setApiError("");
+  try {
+    const url = await getGoogleAuthUrl();
+    window.location.href = url;
+  } catch (err: any) {
+    setApiError(err.message || "Erro ao iniciar login com Google.");
+    setIsLoading(false);
+  }
+};
+```
+
+- [ ] **Step 3: Add onClick to the Google button**
+
+Change the Google button (line 221) from:
+
+```tsx
+<button type="button" disabled={isLoading} className="flex justify-center items-center py-3 px-4 border border-gray-200 dark:border-neutral-800 rounded-xl bg-white/50 dark:bg-neutral-800/50 hover:bg-gray-50 dark:hover:bg-neutral-700/50 transition-all shadow-sm cursor-pointer disabled:opacity-50">
+```
+
+To:
+
+```tsx
+<button type="button" onClick={handleGoogleLogin} disabled={isLoading} className="flex justify-center items-center py-3 px-4 border border-gray-200 dark:border-neutral-800 rounded-xl bg-white/50 dark:bg-neutral-800/50 hover:bg-gray-50 dark:hover:bg-neutral-700/50 transition-all shadow-sm cursor-pointer disabled:opacity-50">
+```
+
+---
+
+### Task 5: Frontend — Wire Google button onClick in RegisterSide.tsx
+
+**Files:**
+- Modify: `frontend/src/components/login/RegisterSide.tsx`
+
+- [ ] **Step 1: Add import**
+
+Add `getGoogleAuthUrl` to the imports. Find the existing authService import and add it:
+
+```typescript
+import { register, getGoogleAuthUrl } from "@/services/authService";
+```
+
+- [ ] **Step 2: Add handler function**
+
+Inside `RegisterSide()`, after state declarations, add:
+
+```typescript
+const handleGoogleLogin = async () => {
+  setIsLoading(true);
+  try {
+    const url = await getGoogleAuthUrl();
+    window.location.href = url;
+  } catch (err: any) {
+    setIsLoading(false);
+  }
+};
+```
+
+- [ ] **Step 3: Add onClick to the Google button**
+
+Change the Google button (line 220) from:
+
+```tsx
+<button type="button" disabled={isLoading} className="flex justify-center items-center py-3 px-4 border border-gray-200 dark:border-neutral-800 rounded-xl bg-white/50 dark:bg-neutral-800/50 hover:bg-gray-50 dark:hover:bg-neutral-700/50 transition-all shadow-sm cursor-pointer disabled:opacity-50">
+```
+
+To:
+
+```tsx
+<button type="button" onClick={handleGoogleLogin} disabled={isLoading} className="flex justify-center items-center py-3 px-4 border border-gray-200 dark:border-neutral-800 rounded-xl bg-white/50 dark:bg-neutral-800/50 hover:bg-gray-50 dark:hover:bg-neutral-700/50 transition-all shadow-sm cursor-pointer disabled:opacity-50">
+```
+
+---
+
+### Task 6: Frontend — Create AuthCallback page
+
+**Files:**
+- Create: `frontend/src/pages/auth/AuthCallback.tsx`
+
+- [ ] **Step 1: Create the callback page**
+
+Create `frontend/src/pages/auth/AuthCallback.tsx`:
+
+```tsx
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "@/context/AuthContext";
+import Loading from "@/Loading";
+
+export default function AuthCallback() {
+  const { user, isLoading } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (isLoading) return;
+
+    if (user) {
+      navigate("/app", { replace: true });
+    } else {
+      navigate("/login?error=oauth_failed", { replace: true });
+    }
+  }, [user, isLoading, navigate]);
+
+  return <Loading />;
+}
+```
+
+---
+
+### Task 7: Frontend — Add /auth/callback route to App.tsx
+
+**Files:**
+- Modify: `frontend/src/App.tsx:1-8,44`
+
+- [ ] **Step 1: Add import**
+
+Add to imports in `frontend/src/App.tsx`:
+
+```typescript
+import AuthCallback from "./pages/auth/AuthCallback";
+```
+
+- [ ] **Step 2: Add route**
+
+Add before the `<Route path="*"` line (line 45):
+
+```tsx
+<Route path="/auth/callback" element={<AuthCallback />} />
+```
+
+- [ ] **Step 3: Verify frontend compiles**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: No errors
+
+---
+
+### Task 8: Manual E2E test
+
+- [ ] **Step 1: Start backend and frontend**
+
+Run backend: `cd backend && npm run dev`
+Run frontend: `cd frontend && npm run dev`
+
+- [ ] **Step 2: Test happy path**
+
+1. Navigate to `http://localhost:5173/login`
+2. Click the Google button
+3. Should redirect to Google consent screen
+4. After authorizing, should redirect back to `/auth/callback`
+5. Should then navigate to `/app` with user authenticated
+
+- [ ] **Step 3: Test error path**
+
+1. Navigate directly to `http://localhost:5173/auth/callback` without session
+2. Should redirect to `/login?error=oauth_failed`
+
+- [ ] **Step 4: Commit all changes**
+
+```bash
+git add backend/.env.example \
+  backend/src/modules/auth/auth.controller.ts \
+  frontend/src/services/authService.ts \
+  frontend/src/components/login/RigthSide.tsx \
+  frontend/src/components/login/RegisterSide.tsx \
+  frontend/src/pages/auth/AuthCallback.tsx \
+  frontend/src/App.tsx
+git commit -m "feat(pav-5): integrate Google OAuth login end-to-end"
+```

--- a/docs/superpowers/specs/2026-06-14-google-oauth-integration-design.md
+++ b/docs/superpowers/specs/2026-06-14-google-oauth-integration-design.md
@@ -1,0 +1,113 @@
+# PAV-5: Google OAuth Integration (Frontend + Backend Fix)
+
+## Objetivo
+
+Integrar o botao "Entrar com Google" no frontend com o backend OAuth ja implementado, usando fluxo Full Redirect.
+
+## Contexto
+
+- Backend tem endpoints `GET /api/auth/google/url` e `GET /api/auth/google/callback` implementados
+- Frontend tem botao Google renderizado em `RigthSide.tsx` e `RegisterSide.tsx` sem onClick
+- O callback do backend retorna JSON em vez de redirecionar — precisa ser corrigido
+- O callback do backend nao persiste `userId` na sessao — precisa ser corrigido
+
+## Fluxo
+
+```
+1. Usuario clica botao Google
+2. Frontend chama GET /api/auth/google/url
+3. Frontend redireciona o navegador para a URL retornada (Google consent)
+4. Google autentica e redireciona para GET /api/auth/google/callback?code=...&state=...
+5. Backend valida state, troca code por tokens, cria/encontra usuario
+6. Backend salva session.userId no cookie
+7. Backend redireciona para FRONTEND_URL/auth/callback
+8. Frontend (pagina /auth/callback) chama GET /api/auth/me
+9. AuthContext recebe o usuario, navega para /app
+```
+
+Em caso de erro no passo 5-6, backend redireciona para `FRONTEND_URL/login?error=oauth_failed`.
+
+## Mudancas
+
+### Backend
+
+#### 1. Nova variavel de ambiente `FRONTEND_URL`
+
+- Adicionar em `.env.example`: `FRONTEND_URL=http://localhost:5173`
+- Usada exclusivamente para o redirect pos-OAuth
+
+#### 2. `auth.controller.ts` — metodo `callback`
+
+Antes (atual):
+```ts
+const result = await this.authService.handleCallback({...});
+return res.json(result);
+```
+
+Depois:
+```ts
+const result = await this.authService.handleCallback({...});
+session.userId = result.session.userId;
+await session.save();
+const frontendUrl = process.env.FRONTEND_URL || "http://localhost:5173";
+return res.redirect(`${frontendUrl}/auth/callback`);
+```
+
+Erro:
+```ts
+catch (error) {
+  const frontendUrl = process.env.FRONTEND_URL || "http://localhost:5173";
+  return res.redirect(`${frontendUrl}/login?error=oauth_failed`);
+}
+```
+
+### Frontend
+
+#### 3. `authService.ts` — nova funcao `getGoogleAuthUrl`
+
+```ts
+export async function getGoogleAuthUrl(): Promise<string> {
+  const response = await fetch(buildUrl("/api/auth/google/url"), {
+    credentials: "include",
+  });
+  const payload = await parseResponse(response);
+  if (!response.ok) {
+    throw createError(payload, "Falha ao obter URL de autenticacao Google.");
+  }
+  return payload.url;
+}
+```
+
+#### 4. `RigthSide.tsx` e `RegisterSide.tsx` — onClick no botao Google
+
+Adicionar handler que:
+1. Chama `getGoogleAuthUrl()`
+2. Redireciona com `window.location.href = url`
+
+#### 5. Nova pagina `AuthCallback.tsx`
+
+Componente em `/auth/callback` que:
+1. Mostra loading spinner
+2. Chama `/auth/me` via AuthContext (que ja faz isso no mount)
+3. Se usuario autenticado, navega para `/app`
+4. Se falha, navega para `/login` com mensagem de erro
+
+#### 6. `App.tsx` — nova rota
+
+```tsx
+<Route path="/auth/callback" element={<AuthCallback />} />
+```
+
+## Criterios de aceite
+
+- Login Google funciona end-to-end (clicar botao -> autenticar -> chegar no /app)
+- Conta criada automaticamente quando nao existe
+- Usuario fica autenticado no app apos login social (cookie de sessao persistido)
+- Erros no OAuth redirecionam para /login com indicacao visual de falha
+- Funciona tanto na pagina de login quanto na de registro
+
+## Fora de escopo
+
+- Login com Facebook ou Apple (botoes existem mas nao serao integrados agora)
+- Refresh de tokens OAuth
+- Linking de contas (usuario ja logado conectar Google)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import NotFound from "./not_found";
 import Loading from "./Loading";
 import LoginPage from "./pages/login/LoginPage";
 import RegisterPage from "./pages/register/RegisterPage";
+import AuthCallback from "./pages/auth/AuthCallback";
 import { useAuth } from "@/context/AuthContext";
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
@@ -43,6 +44,7 @@ function App() {
       />
       <Route path="/login" element={<LoginPage />} />
       <Route path="/register" element={<RegisterPage />} />
+      <Route path="/auth/callback" element={<AuthCallback />} />
       <Route path="*" element={<NotFound />} />
     </Routes>
   );

--- a/frontend/src/components/login/RegisterSide.tsx
+++ b/frontend/src/components/login/RegisterSide.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { register } from "@/services/authService";
+import { register, getGoogleAuthUrl } from "@/services/authService";
 import { Image } from "@unpic/react";
 import { motion } from "framer-motion";
 import { ArrowLeft, Eye, EyeOff } from "lucide-react";
@@ -64,6 +64,16 @@ export default function RegisterSide() {
   
   const [isLoading, setIsLoading] = useState(false);
   const [apiError, setApiError] = useState("");
+
+  const handleGoogleLogin = async () => {
+    setIsLoading(true);
+    try {
+      const url = await getGoogleAuthUrl();
+      window.location.href = url;
+    } catch {
+      setIsLoading(false);
+    }
+  };
 
   const handleRevealPassword = () => setShowPassword((prev) => !prev);
 
@@ -217,7 +227,7 @@ export default function RegisterSide() {
           </div>
         </div>
         <div className="grid grid-cols-3 gap-4">
-          <button type="button" disabled={isLoading} className="flex justify-center items-center py-3 px-4 border border-gray-200 dark:border-neutral-800 rounded-xl bg-white/50 dark:bg-neutral-800/50 hover:bg-gray-50 dark:hover:bg-neutral-700/50 transition-all shadow-sm cursor-pointer disabled:opacity-50">
+          <button type="button" onClick={handleGoogleLogin} disabled={isLoading} className="flex justify-center items-center py-3 px-4 border border-gray-200 dark:border-neutral-800 rounded-xl bg-white/50 dark:bg-neutral-800/50 hover:bg-gray-50 dark:hover:bg-neutral-700/50 transition-all shadow-sm cursor-pointer disabled:opacity-50">
             <Image src="/google.png" alt="Google" width={20} height={20} className="object-contain" />
           </button>
           <button type="button" disabled={isLoading} className="flex justify-center items-center py-3 px-4 border border-gray-200 dark:border-neutral-800 rounded-xl bg-white/50 dark:bg-neutral-800/50 hover:bg-gray-50 dark:hover:bg-neutral-700/50 transition-all shadow-sm cursor-pointer disabled:opacity-50">

--- a/frontend/src/components/login/RigthSide.tsx
+++ b/frontend/src/components/login/RigthSide.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { login } from "@/services/authService";
+import { login, getGoogleAuthUrl } from "@/services/authService";
 import { Image } from "@unpic/react";
 import { motion } from "framer-motion";
 import { ArrowLeft, Eye, EyeOff } from "lucide-react";
@@ -54,6 +54,18 @@ export default function RightSide() {
   const [passwordError, setPasswordError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [apiError, setApiError] = useState("");
+
+  const handleGoogleLogin = async () => {
+    setIsLoading(true);
+    setApiError("");
+    try {
+      const url = await getGoogleAuthUrl();
+      window.location.href = url;
+    } catch (err: any) {
+      setApiError(err.message || "Erro ao iniciar login com Google.");
+      setIsLoading(false);
+    }
+  };
 
   const handleRevealPassword = () => setShowPassword((prev) => !prev);
 
@@ -218,7 +230,7 @@ export default function RightSide() {
           </div>
         </div>
         <div className="grid grid-cols-3 gap-4">
-          <button type="button" disabled={isLoading} className="flex justify-center items-center py-3 px-4 border border-gray-200 dark:border-neutral-800 rounded-xl bg-white/50 dark:bg-neutral-800/50 hover:bg-gray-50 dark:hover:bg-neutral-700/50 transition-all shadow-sm cursor-pointer disabled:opacity-50">
+          <button type="button" onClick={handleGoogleLogin} disabled={isLoading} className="flex justify-center items-center py-3 px-4 border border-gray-200 dark:border-neutral-800 rounded-xl bg-white/50 dark:bg-neutral-800/50 hover:bg-gray-50 dark:hover:bg-neutral-700/50 transition-all shadow-sm cursor-pointer disabled:opacity-50">
             <Image src="/google.png" alt="Google" width={20} height={20} className="object-contain" />
           </button>
           <button type="button" disabled={isLoading} className="flex justify-center items-center py-3 px-4 border border-gray-200 dark:border-neutral-800 rounded-xl bg-white/50 dark:bg-neutral-800/50 hover:bg-gray-50 dark:hover:bg-neutral-700/50 transition-all shadow-sm cursor-pointer disabled:opacity-50">

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -18,6 +18,7 @@ interface AuthContextData {
   isLoading: boolean;
   login: (credentials: { email: string; password: string }) => Promise<void>;
   logout: () => Promise<void>;
+  refreshUser: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextData>({} as AuthContextData);
@@ -50,8 +51,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(null);
   }
 
+  async function refreshUser() {
+    setIsLoading(true);
+    try {
+      const res = await api.get("/auth/me");
+      setUser(res.data.user ?? { id: res.data.userId, email: "" });
+    } catch {
+      setUser(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
   return (
-    <AuthContext.Provider value={{ user, isLoading, login, logout }}>
+    <AuthContext.Provider value={{ user, isLoading, login, logout, refreshUser }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/pages/auth/AuthCallback.tsx
+++ b/frontend/src/pages/auth/AuthCallback.tsx
@@ -1,14 +1,22 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "@/context/AuthContext";
 import Loading from "@/Loading";
 
 export default function AuthCallback() {
-  const { user, isLoading } = useAuth();
+  const { user, isLoading, refreshUser } = useAuth();
   const navigate = useNavigate();
+  const hasRefreshed = useRef(false);
 
   useEffect(() => {
-    if (isLoading) return;
+    if (!hasRefreshed.current) {
+      hasRefreshed.current = true;
+      refreshUser();
+    }
+  }, [refreshUser]);
+
+  useEffect(() => {
+    if (isLoading || !hasRefreshed.current) return;
 
     if (user) {
       navigate("/app", { replace: true });

--- a/frontend/src/pages/auth/AuthCallback.tsx
+++ b/frontend/src/pages/auth/AuthCallback.tsx
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "@/context/AuthContext";
+import Loading from "@/Loading";
+
+export default function AuthCallback() {
+  const { user, isLoading } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (isLoading) return;
+
+    if (user) {
+      navigate("/app", { replace: true });
+    } else {
+      navigate("/login?error=oauth_failed", { replace: true });
+    }
+  }, [user, isLoading, navigate]);
+
+  return <Loading />;
+}

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -123,3 +123,17 @@ export async function getCurrentUser() {
 
   return payload;
 }
+
+export async function getGoogleAuthUrl(): Promise<string> {
+  const response = await fetch(buildUrl("/api/auth/google/url"), {
+    credentials: "include",
+  });
+
+  const payload = await parseResponse(response);
+
+  if (!response.ok) {
+    throw createError(payload, "Falha ao obter URL de autenticacao Google.");
+  }
+
+  return payload.url;
+}

--- a/frontend/tests/unit/context/AuthContext.test.tsx
+++ b/frontend/tests/unit/context/AuthContext.test.tsx
@@ -16,7 +16,7 @@ vi.mock("@/services/api", () => ({
 import { AuthProvider, useAuth } from "@/context/AuthContext";
 
 function TestConsumer() {
-  const { user, isLoading, login, logout } = useAuth();
+  const { user, isLoading, login, logout, refreshUser } = useAuth();
   return (
     <div>
       <span data-testid="loading">{String(isLoading)}</span>
@@ -25,6 +25,7 @@ function TestConsumer() {
         login
       </button>
       <button onClick={() => logout()}>logout</button>
+      <button onClick={() => refreshUser()}>refresh</button>
     </div>
   );
 }
@@ -145,5 +146,59 @@ describe("AuthContext", () => {
     }
     render(<Naked />);
     expect(screen.getByTestId("ctx")).toBeInTheDocument();
+  });
+
+  it("refreshUser atualiza o usuário ao chamar /auth/me novamente", async () => {
+    mockApiGet.mockRejectedValueOnce(new Error("Unauthorized"));
+
+    renderWithProvider();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading").textContent).toBe("false");
+    });
+
+    expect(screen.getByTestId("user").textContent).toBe("null");
+
+    mockApiGet.mockResolvedValueOnce({
+      data: { user: { id: "2", email: "novo@teste.com", name: "Novo" } },
+    });
+
+    await act(async () => {
+      screen.getByRole("button", { name: /refresh/i }).click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading").textContent).toBe("false");
+    });
+
+    const user = JSON.parse(screen.getByTestId("user").textContent!);
+    expect(user.id).toBe("2");
+    expect(user.email).toBe("novo@teste.com");
+  });
+
+  it("refreshUser define user como null quando /auth/me falha", async () => {
+    mockApiGet.mockResolvedValueOnce({
+      data: { user: { id: "1", email: "joao@teste.com" } },
+    });
+
+    renderWithProvider();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading").textContent).toBe("false");
+    });
+
+    expect(screen.getByTestId("user").textContent).not.toBe("null");
+
+    mockApiGet.mockRejectedValueOnce(new Error("Unauthorized"));
+
+    await act(async () => {
+      screen.getByRole("button", { name: /refresh/i }).click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading").textContent).toBe("false");
+    });
+
+    expect(screen.getByTestId("user").textContent).toBe("null");
   });
 });

--- a/frontend/tests/unit/pages/auth/AuthCallback.test.tsx
+++ b/frontend/tests/unit/pages/auth/AuthCallback.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+const mockUseAuth = vi.fn();
+vi.mock("@/context/AuthContext", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+vi.mock("@/Loading", () => ({
+  default: () => <div data-testid="loading">Loading...</div>,
+}));
+
+import AuthCallback from "@/pages/auth/AuthCallback";
+
+describe("AuthCallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("mostra loading enquanto isLoading é true", () => {
+    mockUseAuth.mockReturnValue({
+      user: null,
+      isLoading: true,
+      refreshUser: vi.fn(),
+    });
+
+    render(<AuthCallback />);
+
+    expect(screen.getByTestId("loading")).toBeInTheDocument();
+  });
+
+  it("navega para /app quando user existe", async () => {
+    const refreshUser = vi.fn();
+    mockUseAuth
+      .mockReturnValueOnce({ user: null, isLoading: true, refreshUser })
+      .mockReturnValue({
+        user: { id: "1", email: "test@test.com" },
+        isLoading: false,
+        refreshUser,
+      });
+
+    const { rerender } = render(<AuthCallback />);
+
+    expect(refreshUser).toHaveBeenCalled();
+
+    rerender(<AuthCallback />);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/app", { replace: true });
+    });
+  });
+
+  it("navega para /login com erro quando user é null", async () => {
+    const refreshUser = vi.fn();
+    mockUseAuth
+      .mockReturnValueOnce({ user: null, isLoading: true, refreshUser })
+      .mockReturnValue({ user: null, isLoading: false, refreshUser });
+
+    const { rerender } = render(<AuthCallback />);
+
+    expect(refreshUser).toHaveBeenCalled();
+
+    rerender(<AuthCallback />);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/login?error=oauth_failed", {
+        replace: true,
+      });
+    });
+  });
+
+  it("chama refreshUser ao montar", () => {
+    const refreshUser = vi.fn();
+    mockUseAuth.mockReturnValue({
+      user: null,
+      isLoading: true,
+      refreshUser,
+    });
+
+    render(<AuthCallback />);
+
+    expect(refreshUser).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/tests/unit/services/auth.service.test.tsx
+++ b/frontend/tests/unit/services/auth.service.test.tsx
@@ -252,4 +252,48 @@ describe("authService", () => {
       );
     });
   });
+
+  describe("getGoogleAuthUrl", () => {
+    it("should return Google auth URL on success", async () => {
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({
+          jsonData: { url: "https://accounts.google.com/o/oauth2/auth?state=abc" },
+        })
+      );
+
+      const url = await auth.getGoogleAuthUrl();
+
+      expect(url).toBe("https://accounts.google.com/o/oauth2/auth?state=abc");
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/api/auth/google/url"),
+        expect.objectContaining({ credentials: "include" })
+      );
+    });
+
+    it("should throw error on failure with message", async () => {
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 500,
+          jsonData: { message: "Provider unavailable" },
+        })
+      );
+
+      await expect(auth.getGoogleAuthUrl()).rejects.toThrow("Provider unavailable");
+    });
+
+    it("should throw error on failure without message", async () => {
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 500,
+          jsonData: {},
+        })
+      );
+
+      await expect(auth.getGoogleAuthUrl()).rejects.toThrow(
+        "Falha ao obter URL de autenticacao Google."
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Descricao

Integra o botao "Entrar com Google" no frontend com o backend OAuth, usando fluxo Full Redirect.

**Backend:**
- Corrigido callback OAuth para usar `req.session` (compartilhado com middleware `withSession`) em vez de criar instancia separada de `getIronSession`
- Callback agora salva `session.userId` e redireciona ao frontend (`res.redirect`) em vez de retornar JSON
- Adicionada variavel de ambiente `FRONTEND_URL` para controlar o redirect pos-OAuth

**Frontend:**
- Adicionada funcao `getGoogleAuthUrl()` no `authService.ts`
- Botao Google nas paginas de login e registro agora inicia o fluxo OAuth ao clicar
- Criada pagina `AuthCallback` que detecta a sessao e navega para `/app`
- Adicionado `refreshUser()` no `AuthContext` para re-buscar `/auth/me` apos redirect OAuth

**Testes:**
- Atualizados testes unitarios e de integracao do `auth.controller` para esperar redirects (302) em vez de respostas JSON

## Linear link

https://linear.app/tatame/issue/PAV-5/login-social-google-oauth

## Como foi testado

Testes unitarios e de integracao passando (305/305). Login com Google testado manualmente end-to-end em ambiente local com Docker.
