### PR TITLE
PAV-56: Criar skill do Claude Code para abertura de PRs padronizados

### DIFF
--- a/.claude/skills/abrir-pr-jobs-scraper/skill.md
+++ b/.claude/skills/abrir-pr-jobs-scraper/skill.md
@@ -1,0 +1,149 @@
+---
+name: abrir-pr-jobs-scraper
+description: Use quando o usuario pedir para abrir PR, criar PR, enviar PR, submeter PR, fazer pull request, ou similar no projeto Jobs Scraper Global
+---
+
+# Abrir PR Padronizado — Jobs Scraper Global
+
+Skill para criar Pull Requests padronizados no GitHub, integrando com o Linear para buscar dados da task.
+
+## Pre-requisitos
+
+Antes de iniciar, verifique se todas as ferramentas estao disponiveis:
+
+| Ferramenta | Como verificar | Se ausente |
+|---|---|---|
+| MCP Linear | Checar se ferramentas `mcp__linear-server__*` estao disponiveis | Informar: "O MCP do Linear nao esta configurado. Adicione o server `linear-server` nas configuracoes do Claude Code." e parar |
+| GitHub CLI | Rodar `gh --version` | Informar: "O GitHub CLI (gh) nao esta instalado. Instale com `brew install gh`." e parar |
+| Git | Rodar `git --version` | Informar: "Git nao esta instalado." e parar |
+| npm | Rodar `npm --version` | Informar: "npm nao esta instalado." e parar |
+
+Se qualquer ferramenta estiver ausente, informe ao usuario qual esta faltando e **pare a execucao**.
+
+## Fluxo
+
+Siga os passos abaixo na ordem, sem pular etapas.
+
+### Passo 0: Verificar pre-requisitos
+
+Rode os comandos de verificacao da tabela acima. Se algum falhar, informe e pare.
+
+### Passo 1: Identificar task Linear
+
+1. Obter o nome da branch atual: `git branch --show-current`
+2. Tentar extrair o padrao `PAV-\d+` (case insensitive) do nome da branch
+3. **Se encontrou** um codigo PAV-XX:
+   - Perguntar ao usuario: "A task desenvolvida foi a **PAV-XX**?"
+   - Se confirmar, usar esse codigo
+   - Se negar, perguntar qual e a task
+4. **Se nao encontrou** padrao na branch:
+   - Perguntar ao usuario: "Qual e o codigo da task no Linear? (ex: PAV-42)"
+
+### Passo 2: Buscar dados da task no Linear
+
+1. Usar `mcp__linear-server__get_issue` com o codigo da task
+2. Extrair: **titulo** e **URL** da task
+3. **Se a task nao for encontrada:**
+   - Informar ao usuario
+   - Sugerir: "Deseja criar uma nova task usando `/criar-task-linear`?"
+   - Alternativamente, permitir continuar com titulo e descricao manuais
+
+### Passo 3: Verificar commits
+
+1. Buscar os commits da branch que estao a frente de develop:
+   ```bash
+   git fetch origin develop
+   git log origin/develop..HEAD --oneline
+   ```
+2. **Se nao houver commits a frente de develop:**
+   - Informar: "Esta branch nao tem commits a frente de develop. Nao ha mudancas para abrir PR."
+   - Parar a execucao
+3. **Se ja existir um PR aberto para essa branch:**
+   - Verificar com: `gh pr list --head $(git branch --show-current) --repo Benevanio/Jobs_Scraper_Global --state open`
+   - Se existir, informar ao usuario e perguntar se quer atualizar o PR existente ou parar
+
+### Passo 4: Rodar testes
+
+1. Rodar testes do backend:
+   ```bash
+   cd backend && npm test 2>&1
+   ```
+2. Rodar testes do frontend:
+   ```bash
+   cd frontend && npm test 2>&1
+   ```
+3. Consolidar os resultados em uma string, ex:
+   - Se todos passaram: "Testes unitarios passando — Backend: 305/305 | Frontend: 42/42"
+   - Se houve falhas: "Backend: 300/305 (5 falhando) | Frontend: 42/42"
+4. **Se testes falharem:** nao bloquear. Mostrar o resultado no preview — o usuario decide se prossegue.
+
+### Passo 5: Gerar descricao do PR
+
+1. Obter o diff completo contra develop:
+   ```bash
+   git diff origin/develop..HEAD
+   ```
+2. Obter a lista de commits:
+   ```bash
+   git log origin/develop..HEAD --oneline
+   ```
+3. Gerar um **resumo curto em linguagem natural** das mudancas:
+   - Foco no que foi desenvolvido
+   - Como as mudancas se relacionam com a task e o projeto
+   - Texto conciso (3-5 frases no maximo)
+
+### Passo 6: Montar e mostrar preview
+
+Montar o PR completo e mostrar ao usuario:
+
+**Titulo:**
+```
+PAV-XX: <titulo da task no Linear>
+```
+
+**Target:**
+```
+Benevanio/Jobs_Scraper_Global (branch develop)
+```
+
+**Body:**
+```markdown
+## Descricao
+<resumo gerado no passo 5>
+
+## Linear link
+<URL da task no Linear>
+
+## Como foi testado
+<resultado dos testes do passo 4>
+```
+
+Mostrar tudo formatado e perguntar: **"O PR esta correto? Confirma a criacao? (s/n)"**
+
+### Passo 7: Confirmar ou editar
+
+- **Se o usuario confirmar:** seguir para o passo 8
+- **Se o usuario nao confirmar:**
+  - Perguntar o que deseja alterar
+  - Ajustar os campos conforme solicitado
+  - Mostrar o preview novamente (voltar ao passo 6)
+
+### Passo 8: Criar o PR
+
+1. Criar o PR via GitHub CLI:
+   ```bash
+   gh pr create \
+     --repo Benevanio/Jobs_Scraper_Global \
+     --base develop \
+     --title "PAV-XX: <titulo>" \
+     --body "<body completo>"
+   ```
+2. Confirmar ao usuario com o link do PR criado
+
+## Erros comuns
+
+- **Nao verificar pre-requisitos** — sempre verificar antes de iniciar
+- **Nao confirmar a task com o usuario** — sempre perguntar, mesmo que a branch seja sugestiva
+- **Criar PR sem preview** — sempre mostrar preview e aguardar confirmacao
+- **Bloquear por causa de testes falhando** — mostrar as falhas, mas deixar o usuario decidir
+- **Esquecer de buscar origin/develop atualizado** — sempre rodar `git fetch origin develop` antes de comparar

--- a/.claude/skills/abrir-pr-jobs-scraper/skill.md
+++ b/.claude/skills/abrir-pr-jobs-scraper/skill.md
@@ -130,7 +130,14 @@ Mostrar tudo formatado e perguntar: **"O PR esta correto? Confirma a criacao? (s
 
 ### Passo 8: Criar o PR
 
-1. Criar o PR via GitHub CLI:
+1. Verificar se a branch foi enviada ao remote:
+   ```bash
+   git ls-remote --heads origin $(git branch --show-current)
+   ```
+   - **Se a branch nao existe no remote:** perguntar ao usuario: "A branch ainda nao foi enviada ao remote. Deseja fazer push agora? (s/n)"
+   - Se confirmar, rodar: `git push -u origin $(git branch --show-current)`
+   - Se negar, parar a execucao
+2. Criar o PR via GitHub CLI:
    ```bash
    gh pr create \
      --repo Benevanio/Jobs_Scraper_Global \
@@ -138,7 +145,7 @@ Mostrar tudo formatado e perguntar: **"O PR esta correto? Confirma a criacao? (s
      --title "PAV-XX: <titulo>" \
      --body "<body completo>"
    ```
-2. Confirmar ao usuario com o link do PR criado
+3. Confirmar ao usuario com o link do PR criado
 
 ## Erros comuns
 

--- a/docs/superpowers/plans/2026-06-17-abrir-pr-jobs-scraper.md
+++ b/docs/superpowers/plans/2026-06-17-abrir-pr-jobs-scraper.md
@@ -1,0 +1,235 @@
+# abrir-pr-jobs-scraper Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create a Claude Code skill that automates standardized PR creation on GitHub, integrating with Linear for task data.
+
+**Architecture:** Single Markdown skill file at `.claude/skills/abrir-pr-jobs-scraper/skill.md` following the same pattern as the existing `criar-task-linear` skill. The skill contains instructions that Claude follows step-by-step using available tools (MCP Linear, Bash with `gh`/`git`/`npm`).
+
+**Tech Stack:** Claude Code skill (Markdown), GitHub CLI (`gh`), Linear MCP, Git, npm
+
+## Global Constraints
+
+- Skill file follows the exact frontmatter + Markdown pattern of `.claude/skills/criar-task-linear/skill.md`
+- All text in the skill file must be in Portuguese (matching the existing skill)
+- PR target is always `Benevanio/Jobs_Scraper_Global` branch `develop`
+- AGENTS.md rule: never auto-commit — always ask the user before committing
+
+---
+
+### Task 1: Create the skill file
+
+**Files:**
+- Create: `.claude/skills/abrir-pr-jobs-scraper/skill.md`
+
+**Interfaces:**
+- Consumes: Pattern from existing `.claude/skills/criar-task-linear/skill.md`
+- Produces: Fully functional skill invocable as `/abrir-pr-jobs-scraper`
+
+- [ ] **Step 1: Create the skill file with frontmatter and pre-requisites section**
+
+Create `.claude/skills/abrir-pr-jobs-scraper/skill.md` with the following content:
+
+```markdown
+---
+name: abrir-pr-jobs-scraper
+description: Use quando o usuario pedir para abrir PR, criar PR, enviar PR, submeter PR, fazer pull request, ou similar no projeto Jobs Scraper Global
+---
+
+# Abrir PR Padronizado — Jobs Scraper Global
+
+Skill para criar Pull Requests padronizados no GitHub, integrando com o Linear para buscar dados da task.
+
+## Pre-requisitos
+
+Antes de iniciar, verifique se todas as ferramentas estao disponiveis:
+
+| Ferramenta | Como verificar | Se ausente |
+|---|---|---|
+| MCP Linear | Checar se ferramentas `mcp__linear-server__*` estao disponiveis | Informar: "O MCP do Linear nao esta configurado. Adicione o server `linear-server` nas configuracoes do Claude Code." e parar |
+| GitHub CLI | Rodar `gh --version` | Informar: "O GitHub CLI (gh) nao esta instalado. Instale com `brew install gh`." e parar |
+| Git | Rodar `git --version` | Informar: "Git nao esta instalado." e parar |
+| npm | Rodar `npm --version` | Informar: "npm nao esta instalado." e parar |
+
+Se qualquer ferramenta estiver ausente, informe ao usuario qual esta faltando e **pare a execucao**.
+
+## Fluxo
+
+Siga os passos abaixo na ordem, sem pular etapas.
+
+### Passo 0: Verificar pre-requisitos
+
+Rode os comandos de verificacao da tabela acima. Se algum falhar, informe e pare.
+
+### Passo 1: Identificar task Linear
+
+1. Obter o nome da branch atual: `git branch --show-current`
+2. Tentar extrair o padrao `PAV-\d+` (case insensitive) do nome da branch
+3. **Se encontrou** um codigo PAV-XX:
+   - Perguntar ao usuario: "A task desenvolvida foi a **PAV-XX**?"
+   - Se confirmar, usar esse codigo
+   - Se negar, perguntar qual e a task
+4. **Se nao encontrou** padrao na branch:
+   - Perguntar ao usuario: "Qual e o codigo da task no Linear? (ex: PAV-42)"
+
+### Passo 2: Buscar dados da task no Linear
+
+1. Usar `mcp__linear-server__get_issue` com o codigo da task
+2. Extrair: **titulo** e **URL** da task
+3. **Se a task nao for encontrada:**
+   - Informar ao usuario
+   - Sugerir: "Deseja criar uma nova task usando `/criar-task-linear`?"
+   - Alternativamente, permitir continuar com titulo e descricao manuais
+
+### Passo 3: Verificar commits
+
+1. Buscar os commits da branch que estao a frente de develop:
+   ```bash
+   git fetch origin develop
+   git log origin/develop..HEAD --oneline
+   ```
+2. **Se nao houver commits a frente de develop:**
+   - Informar: "Esta branch nao tem commits a frente de develop. Nao ha mudancas para abrir PR."
+   - Parar a execucao
+3. **Se ja existir um PR aberto para essa branch:**
+   - Verificar com: `gh pr list --head $(git branch --show-current) --repo Benevanio/Jobs_Scraper_Global --state open`
+   - Se existir, informar ao usuario e perguntar se quer atualizar o PR existente ou parar
+
+### Passo 4: Rodar testes
+
+1. Rodar testes do backend:
+   ```bash
+   cd backend && npm test 2>&1
+   ```
+2. Rodar testes do frontend:
+   ```bash
+   cd frontend && npm test 2>&1
+   ```
+3. Consolidar os resultados em uma string, ex:
+   - Se todos passaram: "Testes unitarios passando — Backend: 305/305 | Frontend: 42/42"
+   - Se houve falhas: "Backend: 300/305 (5 falhando) | Frontend: 42/42"
+4. **Se testes falharem:** nao bloquear. Mostrar o resultado no preview — o usuario decide se prossegue.
+
+### Passo 5: Gerar descricao do PR
+
+1. Obter o diff completo contra develop:
+   ```bash
+   git diff origin/develop..HEAD
+   ```
+2. Obter a lista de commits:
+   ```bash
+   git log origin/develop..HEAD --oneline
+   ```
+3. Gerar um **resumo curto em linguagem natural** das mudancas:
+   - Foco no que foi desenvolvido
+   - Como as mudancas se relacionam com a task e o projeto
+   - Texto conciso (3-5 frases no maximo)
+
+### Passo 6: Montar e mostrar preview
+
+Montar o PR completo e mostrar ao usuario:
+
+**Titulo:**
+```
+PAV-XX: <titulo da task no Linear>
+```
+
+**Target:**
+```
+Benevanio/Jobs_Scraper_Global (branch develop)
+```
+
+**Body:**
+```markdown
+## Descricao
+<resumo gerado no passo 5>
+
+## Linear link
+<URL da task no Linear>
+
+## Como foi testado
+<resultado dos testes do passo 4>
+```
+
+Mostrar tudo formatado e perguntar: **"O PR esta correto? Confirma a criacao? (s/n)"**
+
+### Passo 7: Confirmar ou editar
+
+- **Se o usuario confirmar:** seguir para o passo 8
+- **Se o usuario nao confirmar:**
+  - Perguntar o que deseja alterar
+  - Ajustar os campos conforme solicitado
+  - Mostrar o preview novamente (voltar ao passo 6)
+
+### Passo 8: Criar o PR
+
+1. Criar o PR via GitHub CLI:
+   ```bash
+   gh pr create \
+     --repo Benevanio/Jobs_Scraper_Global \
+     --base develop \
+     --title "PAV-XX: <titulo>" \
+     --body "<body completo>"
+   ```
+2. Confirmar ao usuario com o link do PR criado
+
+## Erros comuns
+
+- **Nao verificar pre-requisitos** — sempre verificar antes de iniciar
+- **Nao confirmar a task com o usuario** — sempre perguntar, mesmo que a branch seja sugestiva
+- **Criar PR sem preview** — sempre mostrar preview e aguardar confirmacao
+- **Bloquear por causa de testes falhando** — mostrar as falhas, mas deixar o usuario decidir
+- **Esquecer de buscar origin/develop atualizado** — sempre rodar `git fetch origin develop` antes de comparar
+```
+
+- [ ] **Step 2: Verify the skill is discoverable**
+
+Run: invoke the skill to confirm Claude Code recognizes it:
+```
+/abrir-pr-jobs-scraper
+```
+Expected: The skill content is loaded and Claude begins following the instructions (starting with pre-requisite checks). Cancel after confirming it's recognized — no need to create an actual PR.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/abrir-pr-jobs-scraper/skill.md
+git commit -m "feat(pav-56): criar skill abrir-pr-jobs-scraper para PRs padronizados"
+```
+
+---
+
+### Task 2: Register skill in settings description
+
+**Files:**
+- Check: `.claude/settings.local.json` (no changes expected)
+
+**Interfaces:**
+- Consumes: Skill file from Task 1
+- Produces: Confirmation that skill appears in available skills list
+
+The skill should be auto-discovered from `.claude/skills/`. This task verifies that by checking the skills list shown in system-reminder messages.
+
+- [ ] **Step 1: Verify skill appears in available skills**
+
+Start a new Claude Code conversation and check that `abrir-pr-jobs-scraper` appears in the system-reminder skills list. No file changes needed — skills in `.claude/skills/` are auto-discovered.
+
+- [ ] **Step 2: Test the full flow (dry run)**
+
+Invoke `/abrir-pr-jobs-scraper` and walk through the full flow on the current branch:
+1. Confirm pre-requisites are checked
+2. Confirm task detection works (extracts PAV-XX from branch name)
+3. Confirm Linear integration fetches task data
+4. Confirm tests are run for both backend and frontend
+5. Confirm description is generated from commits/diffs
+6. Confirm preview is shown with correct format
+7. Cancel at the confirmation step (do not actually create the PR)
+
+Expected: All steps execute correctly up to the confirmation prompt.
+
+- [ ] **Step 3: Commit spec and plan docs**
+
+```bash
+git add docs/superpowers/specs/2026-06-17-abrir-pr-padronizado-design.md docs/superpowers/plans/2026-06-17-abrir-pr-jobs-scraper.md
+git commit -m "docs(pav-56): adicionar spec e plano de implementacao da skill abrir-pr"
+```

--- a/docs/superpowers/specs/2026-06-17-abrir-pr-padronizado-design.md
+++ b/docs/superpowers/specs/2026-06-17-abrir-pr-padronizado-design.md
@@ -1,0 +1,112 @@
+# Design: Skill abrir-pr-jobs-scraper
+
+**Task:** [PAV-56](https://linear.app/tatame/issue/PAV-56/criar-skill-do-claude-code-para-abertura-de-prs-padronizados)
+**Data:** 2026-06-17
+**Abordagem:** Skill pura em Markdown (sem scripts auxiliares)
+
+## Objetivo
+
+Criar uma skill do Claude Code que automatiza a abertura de Pull Requests padronizados no GitHub, integrando com o Linear para buscar dados da task e garantindo consistencia no formato.
+
+## Estrutura
+
+Arquivo unico: `.claude/skills/abrir-pr-jobs-scraper/skill.md`
+
+Frontmatter:
+- `name: abrir-pr-jobs-scraper`
+- `description`: acionada quando o usuario pedir para abrir PR, criar PR, enviar PR, submeter PR, ou similar
+
+Segue o mesmo padrao da skill `criar-task-linear`.
+
+## Pre-requisitos
+
+A skill deve verificar antes de iniciar o fluxo:
+
+| Ferramenta | Como verificar | Se ausente |
+|---|---|---|
+| MCP Linear | Checar se ferramentas `mcp__linear-server__*` estao disponiveis | Informar e parar |
+| GitHub CLI (`gh`) | `gh --version` | Informar e parar |
+| Git | `git --version` | Informar e parar |
+| npm | `npm --version` | Informar e parar |
+
+## Fluxo
+
+```
+0. Verificar pre-requisitos
+   ├── MCP Linear disponivel?
+   ├── gh instalado?
+   ├── git disponivel?
+   └── npm disponivel?
+   → Se algum faltar, informar e parar
+
+1. Identificar task Linear
+   ├── Extrair padrao PAV-XX da branch atual (git branch --show-current)
+   ├── Se encontrou → "A task desenvolvida foi a PAV-XX?" (confirmar)
+   └── Se nao encontrou → perguntar qual e a task
+
+2. Buscar dados da task no Linear
+   └── mcp__linear-server__get_issue → titulo, URL
+
+3. Rodar testes
+   ├── Rodar testes do backend (cd backend && npm test)
+   ├── Rodar testes do frontend (cd frontend && npm test)
+   └── Consolidar resultado (ex: "Backend: 305/305 | Frontend: 42/42")
+
+4. Gerar descricao do PR
+   ├── Listar commits da branch vs develop (git log)
+   ├── Analisar diffs (git diff origin/develop)
+   └── Gerar resumo curto em linguagem natural, relacionando com a task e o projeto
+
+5. Montar preview do PR
+   ├── Titulo: "PAV-XX: <titulo da task no Linear>"
+   ├── Descricao: template estruturado
+   └── Mostrar tudo ao usuario formatado
+
+6. Confirmar ou editar
+   ├── Se confirma → criar PR
+   └── Se nao → perguntar o que quer alterar, regenerar preview
+
+7. Criar PR
+   └── gh pr create --base develop --repo Benevanio/Jobs_Scraper_Global --title "..." --body "..."
+```
+
+## Template do PR
+
+**Titulo:** `PAV-XX: <titulo da task no Linear>`
+
+**Body:**
+
+```markdown
+## Descricao
+<resumo curto em linguagem natural das mudancas, contextualizando com a task e o projeto>
+
+## Linear link
+<URL da issue no Linear>
+
+## Como foi testado
+<resultado consolidado dos testes, ex: "Testes unitarios passando — Backend: 305/305 | Frontend: 42/42">
+```
+
+O campo "Como foi testado" vem pre-preenchido com o resultado dos testes, mas o usuario pode editar no preview.
+
+## Tratamento de erros
+
+| Cenario | Comportamento |
+|---|---|
+| Task nao encontrada no Linear | Informar ao usuario. Sugerir criar uma nova task via `/criar-task-linear`. Alternativamente, permitir continuar com titulo e descricao manuais |
+| Testes falhando | Mostrar resultado com falhas no preview. Nao bloquear — usuario decide se prossegue |
+| Branch sem commits a frente de develop | Informar que nao ha mudancas e parar |
+| PR ja existe para essa branch | Informar e perguntar se quer atualizar o existente ou parar |
+| Remote/repo inacessivel | Informar e parar |
+
+## Target do PR
+
+O PR e sempre criado contra o repositorio `Benevanio/Jobs_Scraper_Global` na branch `develop`, usando `gh pr create --repo Benevanio/Jobs_Scraper_Global --base develop`.
+
+## Decisoes de design
+
+- **Deteccao de task:** Tenta extrair PAV-XX da branch, mas sempre confirma com o usuario. Se a branch nao e sugestiva, pergunta diretamente.
+- **Descricao automatica:** Resumo em linguagem natural gerado pelo Claude a partir dos commits/diffs — texto curto focado no que foi desenvolvido e como se relaciona com a task.
+- **Testes:** Roda backend e frontend automaticamente, preenche o campo, mas usuario pode editar no preview.
+- **Sem scripts auxiliares:** Toda a logica e executada pelo Claude usando ferramentas disponvieis (MCP, Bash).
+- **Target fixo:** Sempre `Benevanio/Jobs_Scraper_Global` branch `develop`.

--- a/docs/superpowers/specs/2026-06-17-abrir-pr-padronizado-design.md
+++ b/docs/superpowers/specs/2026-06-17-abrir-pr-padronizado-design.md
@@ -108,5 +108,5 @@ O PR e sempre criado contra o repositorio `Benevanio/Jobs_Scraper_Global` na bra
 - **Deteccao de task:** Tenta extrair PAV-XX da branch, mas sempre confirma com o usuario. Se a branch nao e sugestiva, pergunta diretamente.
 - **Descricao automatica:** Resumo em linguagem natural gerado pelo Claude a partir dos commits/diffs — texto curto focado no que foi desenvolvido e como se relaciona com a task.
 - **Testes:** Roda backend e frontend automaticamente, preenche o campo, mas usuario pode editar no preview.
-- **Sem scripts auxiliares:** Toda a logica e executada pelo Claude usando ferramentas disponvieis (MCP, Bash).
+- **Sem scripts auxiliares:** Toda a logica e executada pelo Claude usando ferramentas disponiveis (MCP, Bash).
 - **Target fixo:** Sempre `Benevanio/Jobs_Scraper_Global` branch `develop`.


### PR DESCRIPTION
## Descricao
Criação da skill `abrir-pr-jobs-scraper` no Claude Code para automatizar a abertura de Pull Requests padronizados. A skill integra com o Linear para buscar dados da task, analisa commits e testes da branch, gera uma descrição automática do PR e solicita confirmação do usuário antes de criar. Inclui também a spec de design e o plano de implementação documentados.

## Linear link
https://linear.app/tatame/issue/PAV-56/criar-skill-do-claude-code-para-abertura-de-prs-padronizados

## Como foi testado
Backend: 305/305 passando | Frontend: 144/148 (4 falhando em jobsService.test.ts — falhas pré-existentes, não relacionadas a esta task)