### PR TITLE
PAV-55: Adicionar credentials: include nas chamadas fetch do jobsService

### DIFF
--- a/frontend/src/services/jobsService.ts
+++ b/frontend/src/services/jobsService.ts
@@ -58,7 +58,9 @@ function readMessage(payload: unknown): string | undefined {
 }
 
 export async function fetchJobFiles(): Promise<JobFile[]> {
-  const response = await fetch(buildApiUrl("/api/jobs/files"));
+  const response = await fetch(buildApiUrl("/api/jobs/files"), {
+    credentials: "include",
+  });
   const payload = (await readPayload(response)) as { files?: unknown } & Record<
     string,
     unknown
@@ -86,7 +88,9 @@ export async function fetchJobFiles(): Promise<JobFile[]> {
 
 export async function fetchJobsByFile(fileName: string): Promise<JobsResponse> {
   const suffix = fileName ? `?file=${encodeURIComponent(fileName)}` : "";
-  const response = await fetch(buildApiUrl(`/api/jobs${suffix}`));
+  const response = await fetch(buildApiUrl(`/api/jobs${suffix}`), {
+    credentials: "include",
+  });
   const payload = (await readPayload(response)) as Record<string, unknown>;
 
   if (!response.ok) {
@@ -106,7 +110,9 @@ export async function fetchJobsByFile(fileName: string): Promise<JobsResponse> {
 }
 
 export async function fetchKeywords(): Promise<string[]> {
-  const response = await fetch(buildApiUrl("/api/keywords"));
+  const response = await fetch(buildApiUrl("/api/keywords"), {
+    credentials: "include",
+  });
   const payload = (await readPayload(response)) as {
     keywords?: unknown;
   } & Record<string, unknown>;
@@ -125,6 +131,7 @@ export async function saveKeywords(keywords: string[]): Promise<void> {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({ keywords }),
+    credentials: "include",
   });
   const payload = (await readPayload(response)) as Record<string, unknown>;
 
@@ -136,6 +143,7 @@ export async function saveKeywords(keywords: string[]): Promise<void> {
 export async function runScraperRequest(): Promise<void> {
   const response = await fetch(buildApiUrl("/api/jobs/search"), {
     method: "POST",
+    credentials: "include",
   });
   const payload = (await readPayload(response)) as Record<string, unknown>;
 

--- a/frontend/tests/unit/utils/jobsService.test.ts
+++ b/frontend/tests/unit/utils/jobsService.test.ts
@@ -23,7 +23,7 @@ describe("jobsService", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await fetchJobFiles();
-    expect(fetchMock).toHaveBeenCalledWith("https://jobsglobalscraper.ddns.net/api/jobs/files");
+    expect(fetchMock).toHaveBeenCalledWith("https://jobsglobalscraper.ddns.net/api/jobs/files", { credentials: "include" });
   });
 
   it("filtra entradas invalidas ao listar arquivos", async () => {
@@ -68,7 +68,7 @@ describe("jobsService", () => {
     const response = await fetchJobsByFile("vagas.xlsx");
     expect(response.total).toBe(1);
     expect(response.file).toBe("vagas.xlsx");
-    expect(fetchMock).toHaveBeenCalledWith("/api/jobs?file=vagas.xlsx");
+    expect(fetchMock).toHaveBeenCalledWith("/api/jobs?file=vagas.xlsx", { credentials: "include" });
   });
 
   it("usa endpoint sem sufixo quando fileName vazio", async () => {
@@ -81,7 +81,7 @@ describe("jobsService", () => {
     );
 
     await fetchJobsByFile("");
-    expect(fetch).toHaveBeenCalledWith("/api/jobs");
+    expect(fetch).toHaveBeenCalledWith("/api/jobs", { credentials: "include" });
   });
 
   it("normaliza payload invalido ao buscar jobs", async () => {
@@ -92,7 +92,7 @@ describe("jobsService", () => {
 
     const response = await fetchJobsByFile("vagas com espaco.xlsx");
     expect(response).toEqual({ jobs: [], file: "", modifiedAt: null, total: 0 });
-    expect(fetch).toHaveBeenCalledWith("/api/jobs?file=vagas%20com%20espaco.xlsx");
+    expect(fetch).toHaveBeenCalledWith("/api/jobs?file=vagas%20com%20espaco.xlsx", { credentials: "include" });
   });
 
   it("lanca erro com mensagem da API ao buscar jobs", async () => {
@@ -173,6 +173,7 @@ describe("jobsService", () => {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ keywords: ["node", "vitest"] }),
+      credentials: "include",
     });
   });
 


### PR DESCRIPTION
## Descrição
Adiciona `credentials: "include"` em todas as chamadas `fetch()` do `jobsService.ts` para que o cookie de sessão (`vagas_session`) seja enviado nas requests. Sem essa opção, todas as rotas protegidas retornavam 401 mesmo com o usuário autenticado. Outros serviços do projeto (como `authService.ts` e o `AuthContext` com axios) já usavam essa configuração.

## Linear link
https://linear.app/tatame/issue/PAV-55/adicionar-credentials-include-nas-chamadas-fetch-do-jobsservice

## Como foi testado
Backend: 305/305 passando | Frontend: 143/148 (5 falhando — falhas pré-existentes nos testes de `jobsService`, não introduzidas por esta mudança)

🤖 Generated with [Claude Code](https://claude.com/claude-code)