### PR TITLE
PAV-6: Login social LinkedIn (OAuth)

### DIFF
--- a/.claude/skills/abrir-pr-jobs-scraper/skill.md
+++ b/.claude/skills/abrir-pr-jobs-scraper/skill.md
@@ -50,16 +50,22 @@ Rode os comandos de verificacao da tabela acima. Se algum falhar, informe e pare
 
 ### Passo 3: Verificar commits
 
+> **Importante:** Este projeto usa um modelo de fork. O remote `origin` aponta para o fork do
+> desenvolvedor (ex: `jeremiassnts/Jobs_Scraper_Global`) e o remote `upstream` aponta para o
+> repositorio principal (`Benevanio/Jobs_Scraper_Global`). O PR sempre deve ser criado do fork
+> (origin) para o upstream, usando a flag `--head` do `gh pr create`.
+
 1. Buscar os commits da branch que estao a frente de develop:
    ```bash
-   git fetch origin develop
-   git log origin/develop..HEAD --oneline
+   git fetch upstream develop
+   git log upstream/develop..HEAD --oneline
    ```
 2. **Se nao houver commits a frente de develop:**
    - Informar: "Esta branch nao tem commits a frente de develop. Nao ha mudancas para abrir PR."
    - Parar a execucao
 3. **Se ja existir um PR aberto para essa branch:**
-   - Verificar com: `gh pr list --head $(git branch --show-current) --repo Benevanio/Jobs_Scraper_Global --state open`
+   - Detectar o owner do fork: `gh repo view --json owner -q .owner.login` (rodado no diretorio do projeto, que aponta para origin)
+   - Verificar com: `gh pr list --head <owner-do-fork>:$(git branch --show-current) --repo Benevanio/Jobs_Scraper_Global --state open`
    - Se existir, informar ao usuario e perguntar se quer atualizar o PR existente ou parar
 
 ### Passo 4: Rodar testes
@@ -81,11 +87,11 @@ Rode os comandos de verificacao da tabela acima. Se algum falhar, informe e pare
 
 1. Obter o diff completo contra develop:
    ```bash
-   git diff origin/develop..HEAD
+   git diff upstream/develop..HEAD
    ```
 2. Obter a lista de commits:
    ```bash
-   git log origin/develop..HEAD --oneline
+   git log upstream/develop..HEAD --oneline
    ```
 3. Gerar um **resumo curto em linguagem natural** das mudancas:
    - Foco no que foi desenvolvido
@@ -130,22 +136,31 @@ Mostrar tudo formatado e perguntar: **"O PR esta correto? Confirma a criacao? (s
 
 ### Passo 8: Criar o PR
 
-1. Verificar se a branch foi enviada ao remote:
+> **Modelo de fork:** O PR e criado do fork (origin) para o upstream (Benevanio/Jobs_Scraper_Global).
+> E necessario usar `--head <owner-do-fork>:<branch>` para que o GitHub identifique corretamente
+> a branch de origem no fork.
+
+1. Verificar se a branch foi enviada ao remote (origin = fork):
    ```bash
    git ls-remote --heads origin $(git branch --show-current)
    ```
    - **Se a branch nao existe no remote:** perguntar ao usuario: "A branch ainda nao foi enviada ao remote. Deseja fazer push agora? (s/n)"
    - Se confirmar, rodar: `git push -u origin $(git branch --show-current)`
    - Se negar, parar a execucao
-2. Criar o PR via GitHub CLI:
+2. Detectar o owner do fork:
+   ```bash
+   FORK_OWNER=$(gh repo view --json owner -q .owner.login)
+   ```
+3. Criar o PR via GitHub CLI:
    ```bash
    gh pr create \
      --repo Benevanio/Jobs_Scraper_Global \
      --base develop \
+     --head "$FORK_OWNER:$(git branch --show-current)" \
      --title "PAV-XX: <titulo>" \
      --body "<body completo>"
    ```
-3. Confirmar ao usuario com o link do PR criado
+4. Confirmar ao usuario com o link do PR criado
 
 ## Erros comuns
 
@@ -153,4 +168,5 @@ Mostrar tudo formatado e perguntar: **"O PR esta correto? Confirma a criacao? (s
 - **Nao confirmar a task com o usuario** — sempre perguntar, mesmo que a branch seja sugestiva
 - **Criar PR sem preview** — sempre mostrar preview e aguardar confirmacao
 - **Bloquear por causa de testes falhando** — mostrar as falhas, mas deixar o usuario decidir
-- **Esquecer de buscar origin/develop atualizado** — sempre rodar `git fetch origin develop` antes de comparar
+- **Esquecer de buscar upstream/develop atualizado** — sempre rodar `git fetch upstream develop` antes de comparar
+- **Nao usar --head no gh pr create** — como o projeto usa fork, e obrigatorio passar `--head <owner-do-fork>:<branch>` para o PR ser criado corretamente

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,4 @@
 ## Git
 
 - NUNCA faça commits automaticamente. Sempre pergunte ao usuario antes de commitar.
+- Mensagens de commit devem ser escritas em português.

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -35,6 +35,10 @@ export class AuthService {
       callbackUrl,
     });
 
+    if (!profile.email) {
+      throw new Error("oauth_email_required");
+    }
+
     const user = await findOrCreateUser({
       provider,
       profile,

--- a/backend/src/modules/auth/providers/linkedin.ts
+++ b/backend/src/modules/auth/providers/linkedin.ts
@@ -3,7 +3,7 @@ import {
   buildAuthorizationUrl,
   discovery,
 } from "openid-client";
-import { OAuthProfile } from "../../types/auth.types";
+import { ExchangeCodeParams, OAuthProfile } from "../../types/auth.types";
 
 let _config: Awaited<ReturnType<typeof discovery>> | null = null;
 
@@ -32,20 +32,18 @@ export async function getLinkedinAuthUrl(state: string): Promise<string> {
 }
 
 export async function exchangeLinkedinCode({
-  code,
+  callbackUrl,
   state,
-}: {
-  code: string;
-  state?: string;
-}): Promise<OAuthProfile> {
+}: ExchangeCodeParams): Promise<OAuthProfile> {
   const config = await getConfig();
 
-  const tokens = await authorizationCodeGrant(
-    config,
-    new URL(
-      `${process.env.APP_URL}/auth/linkedin/callback?code=${code}&state=${state}`,
-    ),
-  );
+  if (!state) {
+    throw new Error("State ausente");
+  }
+
+  const tokens = await authorizationCodeGrant(config, new URL(callbackUrl), {
+    expectedState: state,
+  });
 
   const claims = tokens.claims();
 

--- a/backend/tests/integration/routes/auth.routes.test.ts
+++ b/backend/tests/integration/routes/auth.routes.test.ts
@@ -282,6 +282,33 @@ describe("Integration - Auth Routes", () => {
 
       expect(res.headers.location).toContain("/login?error=oauth_failed");
     });
+
+    it("redireciona ao frontend em callback valido para linkedin", async () => {
+      const res = await request(app)
+        .get(`${BASE}/linkedin/callback?code=li-code-123&state=valid-state-abc123`)
+        .expect(302);
+
+      expect(res.headers.location).toContain("/auth/callback");
+      expect(mockAuthService.handleCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: "linkedin",
+          code: "li-code-123",
+          state: "valid-state-abc123",
+        }),
+      );
+    });
+
+    it("redireciona com erro quando profile nao tem email", async () => {
+      mockAuthService.handleCallback.mockRejectedValueOnce(
+        new Error("oauth_email_required"),
+      );
+
+      const res = await request(app)
+        .get(`${BASE}/linkedin/callback?code=abc123&state=valid-state-abc123`)
+        .expect(302);
+
+      expect(res.headers.location).toContain("/login?error=oauth_failed");
+    });
   });
 
   // ── POST /register ────────────────────────────────────────────────────────

--- a/backend/tests/unit/modules/auth/auth.service.test.ts
+++ b/backend/tests/unit/modules/auth/auth.service.test.ts
@@ -16,6 +16,10 @@ vi.mock("../../../../src/modules/auth/providers/auth.provider", () => ({
       getAuthUrl: mocks.getAuthUrl,
       exchangeCode: mocks.exchangeCode,
     },
+    linkedin: {
+      getAuthUrl: mocks.getAuthUrl,
+      exchangeCode: mocks.exchangeCode,
+    },
   },
 }));
 
@@ -130,6 +134,19 @@ describe("AuthService", () => {
       await expect(service.handleCallback(validCallbackParams)).rejects.toThrow(
         "db error",
       );
+    });
+
+    it("throws when profile has no email", async () => {
+      mocks.exchangeCode.mockResolvedValueOnce({
+        ...mockProfile,
+        email: undefined,
+      });
+
+      await expect(service.handleCallback(validCallbackParams)).rejects.toThrow(
+        "oauth_email_required",
+      );
+
+      expect(mocks.findOrCreateUser).not.toHaveBeenCalled();
     });
 
     it("calls findOrCreateUser with provider and profile", async () => {

--- a/backend/tests/unit/utils/logger.test.ts
+++ b/backend/tests/unit/utils/logger.test.ts
@@ -65,6 +65,22 @@ describe("logger", () => {
     vi.resetModules();
   });
 
+  it("logInfo works without ctx", async () => {
+    const spy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    const { logInfo } = await import("../../../src/logger.ts");
+    logInfo("no context");
+
+    const output = spy.mock.calls.map((c) => String(c[0])).join("");
+    const parsed = JSON.parse(output);
+
+    expect(parsed.msg).toBe("no context");
+
+    spy.mockRestore();
+  });
+
   it("defaults to info level", async () => {
     delete process.env.LOG_LEVEL;
     vi.resetModules();

--- a/docs/superpowers/plans/2026-06-17-linkedin-oauth.md
+++ b/docs/superpowers/plans/2026-06-17-linkedin-oauth.md
@@ -1,0 +1,502 @@
+# PAV-6: LinkedIn OAuth Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable LinkedIn social login end-to-end, following the same pattern as the existing Google OAuth (PAV-5).
+
+**Architecture:** The backend already has a generic OAuth architecture with `:provider` routes, a provider registry, and a LinkedIn provider file (`linkedin.ts`). The LinkedIn provider has a signature bug that needs fixing. The frontend needs a new `getLinkedinAuthUrl()` service function, LinkedIn button handlers in login/register components, and the Facebook button replaced with LinkedIn. Email-absent profiles must be rejected.
+
+**Tech Stack:** Express + openid-client + iron-session (backend), React + react-router-dom (frontend), Vitest + supertest + @testing-library/react (tests)
+
+## Global Constraints
+
+- Coverage thresholds: 80% lines, functions, branches, statements (frontend `vitest.config.js`)
+- Backend tests use `vitest` + `supertest` with mocked `AuthService` and `iron-session`
+- Frontend tests use `vitest` + `@testing-library/react` with mocked `authService` module
+- All OAuth providers must conform to `OAuthProviderImplementation` interface from `auth.types.ts`
+- Session cookies use `iron-session` with `SESSION_SECRET` env var
+
+---
+
+### Task 1: Fix LinkedIn provider signature and add email validation
+
+**Files:**
+- Modify: `backend/src/modules/auth/providers/linkedin.ts:34-48` (fix `exchangeLinkedinCode` signature)
+- Modify: `backend/src/modules/auth/auth.service.ts:22-49` (add email validation in `handleCallback`)
+- Test: `backend/tests/integration/routes/auth.routes.test.ts` (add LinkedIn-specific and email-absent tests)
+
+**Interfaces:**
+- Consumes: `ExchangeCodeParams` from `backend/src/modules/types/auth.types.ts` — `{ code: string; state?: string; callbackUrl: string }`
+- Produces: `exchangeLinkedinCode(params: ExchangeCodeParams): Promise<OAuthProfile>` matching `OAuthProviderImplementation`
+
+- [ ] **Step 1: Write failing test — LinkedIn callback with valid state**
+
+Add this test inside the existing `describe("GET /:provider/callback")` block in `backend/tests/integration/routes/auth.routes.test.ts`:
+
+```ts
+it("redireciona ao frontend em callback valido para linkedin", async () => {
+  const res = await request(app)
+    .get(`${BASE}/linkedin/callback?code=li-code-123&state=valid-state-abc123`)
+    .expect(302);
+
+  expect(res.headers.location).toContain("/auth/callback");
+  expect(mockAuthService.handleCallback).toHaveBeenCalledWith(
+    expect.objectContaining({
+      provider: "linkedin",
+      code: "li-code-123",
+      state: "valid-state-abc123",
+    }),
+  );
+});
+```
+
+- [ ] **Step 2: Write failing test — email absent redirects with error**
+
+Add this test inside the existing `describe("GET /:provider/callback")` block:
+
+```ts
+it("redireciona com erro quando profile nao tem email", async () => {
+  mockAuthService.handleCallback.mockRejectedValueOnce(
+    new Error("oauth_email_required"),
+  );
+
+  const res = await request(app)
+    .get(`${BASE}/linkedin/callback?code=abc123&state=valid-state-abc123`)
+    .expect(302);
+
+  expect(res.headers.location).toContain("/login?error=oauth_failed");
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+cd backend && npx vitest run tests/integration/routes/auth.routes.test.ts --reporter=verbose
+```
+
+Expected: The new LinkedIn callback test should PASS (routes are already generic), and the email-absent test should also PASS (the controller already catches errors and redirects). If they pass, they confirm existing behavior works — proceed to fix the provider bug.
+
+- [ ] **Step 4: Fix `exchangeLinkedinCode` signature to match `ExchangeCodeParams`**
+
+Replace the function signature and body in `backend/src/modules/auth/providers/linkedin.ts` (lines 34-48):
+
+```ts
+import { ExchangeCodeParams, OAuthProfile } from "../../types/auth.types";
+```
+
+Update the import at line 6, then replace the function:
+
+```ts
+export async function exchangeLinkedinCode({
+  callbackUrl,
+  state,
+}: ExchangeCodeParams): Promise<OAuthProfile> {
+  const config = await getConfig();
+
+  if (!state) {
+    throw new Error("State ausente");
+  }
+
+  const tokens = await authorizationCodeGrant(config, new URL(callbackUrl), {
+    expectedState: state,
+  });
+
+  const claims = tokens.claims();
+
+  if (!claims || typeof claims !== "object") {
+    throw new Error("Invalid LinkedIn claims");
+  }
+
+  const getString = (value: unknown): string | undefined =>
+    typeof value === "string" ? value : undefined;
+
+  const getNumber = (value: unknown): number | undefined =>
+    typeof value === "number" ? value : undefined;
+
+  return {
+    id: getString(claims.sub) ?? "",
+
+    email: getString(claims.email),
+    name: getString(claims.name),
+
+    given_name: getString(claims.given_name),
+    family_name: getString(claims.family_name),
+
+    picture: getString(claims.picture),
+
+    access_token: tokens.access_token,
+    refresh_token: tokens.refresh_token,
+
+    expires_at: getNumber(claims.exp),
+  };
+}
+```
+
+- [ ] **Step 5: Add email validation in `handleCallback`**
+
+In `backend/src/modules/auth/auth.service.ts`, add email check after getting the profile (line 37, before `findOrCreateUser`):
+
+```ts
+async handleCallback({
+  provider,
+  code,
+  state,
+  callbackUrl,
+}: AuthCallbackParams): Promise<{
+  user: User;
+  session: Session;
+}> {
+  const profile = await this.getProfileFromProvider({
+    provider,
+    code,
+    state,
+    callbackUrl,
+  });
+
+  if (!profile.email) {
+    throw new Error("oauth_email_required");
+  }
+
+  const user = await findOrCreateUser({
+    provider,
+    profile,
+  });
+
+  const session = await this.createSession(user);
+
+  return {
+    user,
+    session,
+  };
+}
+```
+
+- [ ] **Step 6: Run all backend tests**
+
+```bash
+cd backend && npx vitest run --reporter=verbose
+```
+
+Expected: All tests pass, including the new LinkedIn-specific tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd backend && git add src/modules/auth/providers/linkedin.ts src/modules/auth/auth.service.ts tests/integration/routes/auth.routes.test.ts && git commit -m "$(cat <<'EOF'
+fix(pav-6): fix LinkedIn provider signature and add email validation
+
+- Fix exchangeLinkedinCode to match ExchangeCodeParams interface (use callbackUrl + expectedState like Google)
+- Add email validation in handleCallback — reject profiles without email
+- Add integration tests for LinkedIn callback and email-absent case
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Add `getLinkedinAuthUrl` to frontend auth service
+
+**Files:**
+- Modify: `frontend/src/services/authService.ts:127-139` (add new function after `getGoogleAuthUrl`)
+- Test: `frontend/tests/unit/services/auth.service.test.tsx` (add LinkedIn tests)
+
+**Interfaces:**
+- Consumes: `buildUrl`, `parseResponse`, `createError` from same file (internal helpers)
+- Produces: `getLinkedinAuthUrl(): Promise<string>` — exported function called by login/register components
+
+- [ ] **Step 1: Write failing tests for `getLinkedinAuthUrl`**
+
+Add a new `describe` block at the end of `frontend/tests/unit/services/auth.service.test.tsx` (before the closing `});` of the root describe):
+
+```tsx
+describe("getLinkedinAuthUrl", () => {
+  it("should return LinkedIn auth URL on success", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        jsonData: { url: "https://www.linkedin.com/oauth/v2/authorization?state=abc" },
+      })
+    );
+
+    const url = await auth.getLinkedinAuthUrl();
+
+    expect(url).toBe("https://www.linkedin.com/oauth/v2/authorization?state=abc");
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/api/auth/linkedin/url"),
+      expect.objectContaining({ credentials: "include" })
+    );
+  });
+
+  it("should throw error on failure with message", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        ok: false,
+        status: 500,
+        jsonData: { message: "Provider unavailable" },
+      })
+    );
+
+    await expect(auth.getLinkedinAuthUrl()).rejects.toThrow("Provider unavailable");
+  });
+
+  it("should throw error on failure without message", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        ok: false,
+        status: 500,
+        jsonData: {},
+      })
+    );
+
+    await expect(auth.getLinkedinAuthUrl()).rejects.toThrow(
+      "Falha ao obter URL de autenticacao LinkedIn."
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd frontend && npx vitest run tests/unit/services/auth.service.test.tsx --reporter=verbose
+```
+
+Expected: FAIL — `auth.getLinkedinAuthUrl is not a function`
+
+- [ ] **Step 3: Implement `getLinkedinAuthUrl`**
+
+Add at the end of `frontend/src/services/authService.ts`:
+
+```ts
+export async function getLinkedinAuthUrl(): Promise<string> {
+  const response = await fetch(buildUrl("/api/auth/linkedin/url"), {
+    credentials: "include",
+  });
+
+  const payload = await parseResponse(response);
+
+  if (!response.ok) {
+    throw createError(payload, "Falha ao obter URL de autenticacao LinkedIn.");
+  }
+
+  return payload.url;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd frontend && npx vitest run tests/unit/services/auth.service.test.tsx --reporter=verbose
+```
+
+Expected: All tests pass, including the 3 new LinkedIn tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd frontend && git add src/services/authService.ts tests/unit/services/auth.service.test.tsx && git commit -m "$(cat <<'EOF'
+feat(pav-6): add getLinkedinAuthUrl to frontend auth service
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Replace Facebook button with LinkedIn in login and register components
+
+**Files:**
+- Modify: `frontend/src/components/login/RigthSide.tsx` (import + handler + button replacement)
+- Modify: `frontend/src/components/login/RegisterSide.tsx` (import + handler + button replacement)
+- Test: `frontend/tests/unit/components/login/RigthSide.test.tsx` (add LinkedIn button test)
+- Test: `frontend/tests/unit/components/login/RegisterSide.test.tsx` (add LinkedIn button test)
+
+**Interfaces:**
+- Consumes: `getLinkedinAuthUrl(): Promise<string>` from `@/services/authService` (Task 2)
+- Produces: LinkedIn login button visible in login and register pages, wired to `handleLinkedinLogin`
+
+- [ ] **Step 1: Write failing test for LinkedIn button in RigthSide**
+
+Add to the mock at the top of `frontend/tests/unit/components/login/RigthSide.test.tsx` — update the mock to include `getLinkedinAuthUrl`:
+
+```tsx
+const mockLogin = vi.fn();
+const mockGetLinkedinAuthUrl = vi.fn();
+
+vi.mock("@/services/authService", () => ({
+  login: (...args: any[]) => mockLogin(...args),
+  getLinkedinAuthUrl: (...args: any[]) => mockGetLinkedinAuthUrl(...args),
+}));
+```
+
+Add `mockGetLinkedinAuthUrl.mockReset();` to the `beforeEach` block.
+
+Add this test at the end of the describe block:
+
+```tsx
+it("redireciona para LinkedIn OAuth ao clicar no botao LinkedIn", async () => {
+  mockGetLinkedinAuthUrl.mockResolvedValueOnce(
+    "https://www.linkedin.com/oauth/v2/authorization?state=abc"
+  );
+
+  render(<RigthSide />);
+
+  const linkedinButton = screen.getByRole("button", { name: /linkedin/i });
+  fireEvent.click(linkedinButton);
+
+  await waitFor(() => {
+    expect(mockGetLinkedinAuthUrl).toHaveBeenCalled();
+    expect(window.location.href).toBe(
+      "https://www.linkedin.com/oauth/v2/authorization?state=abc"
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Write failing test for LinkedIn button in RegisterSide**
+
+Update the mock at the top of `frontend/tests/unit/components/login/RegisterSide.test.tsx`:
+
+```tsx
+const mockRegister = vi.fn();
+const mockGetLinkedinAuthUrl = vi.fn();
+
+vi.mock("@/services/authService", () => ({
+  register: (...args: any[]) => mockRegister(...args),
+  getLinkedinAuthUrl: (...args: any[]) => mockGetLinkedinAuthUrl(...args),
+}));
+```
+
+Add `mockGetLinkedinAuthUrl.mockReset();` to the `beforeEach` block.
+
+Add this test at the end of the describe block:
+
+```tsx
+it("redireciona para LinkedIn OAuth ao clicar no botao LinkedIn", async () => {
+  mockGetLinkedinAuthUrl.mockResolvedValueOnce(
+    "https://www.linkedin.com/oauth/v2/authorization?state=abc"
+  );
+
+  render(<RegisterSide />);
+
+  const linkedinButton = screen.getByRole("button", { name: /linkedin/i });
+  fireEvent.click(linkedinButton);
+
+  await waitFor(() => {
+    expect(mockGetLinkedinAuthUrl).toHaveBeenCalled();
+    expect(window.location.href).toBe(
+      "https://www.linkedin.com/oauth/v2/authorization?state=abc"
+    );
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+cd frontend && npx vitest run tests/unit/components/login/RigthSide.test.tsx tests/unit/components/login/RegisterSide.test.tsx --reporter=verbose
+```
+
+Expected: FAIL — cannot find button with name "linkedin"
+
+- [ ] **Step 4: Implement LinkedIn button in `RigthSide.tsx`**
+
+Update imports at the top of `frontend/src/components/login/RigthSide.tsx`:
+
+```tsx
+import { login, getGoogleAuthUrl, getLinkedinAuthUrl } from "@/services/authService";
+```
+
+Add handler inside the `RightSide` component, after `handleGoogleLogin`:
+
+```tsx
+const handleLinkedinLogin = async () => {
+  setIsLoading(true);
+  setApiError("");
+  try {
+    const url = await getLinkedinAuthUrl();
+    window.location.href = url;
+  } catch (err: any) {
+    setApiError(err.message || "Erro ao iniciar login com LinkedIn.");
+    setIsLoading(false);
+  }
+};
+```
+
+Replace the Facebook button (second button in the grid, around line 236) with:
+
+```tsx
+<button type="button" onClick={handleLinkedinLogin} disabled={isLoading} aria-label="LinkedIn" className="flex justify-center items-center py-3 px-4 border border-gray-200 dark:border-neutral-800 rounded-xl bg-white/50 dark:bg-neutral-800/50 hover:bg-gray-50 dark:hover:bg-neutral-700/50 transition-all shadow-sm cursor-pointer disabled:opacity-50">
+  <svg className="h-5 w-5 fill-[#0A66C2]" viewBox="0 0 24 24">
+    <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+  </svg>
+</button>
+```
+
+- [ ] **Step 5: Implement LinkedIn button in `RegisterSide.tsx`**
+
+Update imports at the top of `frontend/src/components/login/RegisterSide.tsx`:
+
+```tsx
+import { register, getGoogleAuthUrl, getLinkedinAuthUrl } from "@/services/authService";
+```
+
+Add handler inside the `RegisterSide` component, after `handleGoogleLogin`:
+
+```tsx
+const handleLinkedinLogin = async () => {
+  setIsLoading(true);
+  setApiError("");
+  try {
+    const url = await getLinkedinAuthUrl();
+    window.location.href = url;
+  } catch (err: any) {
+    setApiError(err.message || "Erro ao iniciar login com LinkedIn.");
+    setIsLoading(false);
+  }
+};
+```
+
+Replace the Facebook button (second button in the grid, around line 233) with:
+
+```tsx
+<button type="button" onClick={handleLinkedinLogin} disabled={isLoading} aria-label="LinkedIn" className="flex justify-center items-center py-3 px-4 border border-gray-200 dark:border-neutral-800 rounded-xl bg-white/50 dark:bg-neutral-800/50 hover:bg-gray-50 dark:hover:bg-neutral-700/50 transition-all shadow-sm cursor-pointer disabled:opacity-50">
+  <svg className="h-5 w-5 fill-[#0A66C2]" viewBox="0 0 24 24">
+    <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+  </svg>
+</button>
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+cd frontend && npx vitest run tests/unit/components/login/RigthSide.test.tsx tests/unit/components/login/RegisterSide.test.tsx --reporter=verbose
+```
+
+Expected: All tests pass, including the new LinkedIn button tests.
+
+- [ ] **Step 7: Run full test suites**
+
+```bash
+cd backend && npx vitest run --reporter=verbose
+cd frontend && npx vitest run --reporter=verbose
+```
+
+Expected: All backend and frontend tests pass. Coverage thresholds met.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/components/login/RigthSide.tsx frontend/src/components/login/RegisterSide.tsx frontend/tests/unit/components/login/RigthSide.test.tsx frontend/tests/unit/components/login/RegisterSide.test.tsx && git commit -m "$(cat <<'EOF'
+feat(pav-6): replace Facebook button with LinkedIn in login/register
+
+- Add handleLinkedinLogin handler in RigthSide and RegisterSide
+- Replace Facebook button with LinkedIn button using inline SVG icon
+- Add tests for LinkedIn button click triggering OAuth redirect
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-06-17-linkedin-oauth-integration-design.md
+++ b/docs/superpowers/specs/2026-06-17-linkedin-oauth-integration-design.md
@@ -1,0 +1,122 @@
+# PAV-6: LinkedIn OAuth Integration
+
+## Objetivo
+
+Integrar login social com LinkedIn no app, seguindo o mesmo padrao do Google OAuth (PAV-5). O backend ja possui o provider implementado — o foco e validar o backend e implementar o frontend.
+
+## Contexto
+
+- Backend tem provider `linkedin.ts` implementado com `openid-client` (mesmo padrao do Google)
+- Rotas genericas `GET /api/auth/:provider/url` e `GET /api/auth/:provider/callback` ja funcionam
+- Provider registrado em `auth.provider.ts`, types incluem `"linkedin"` no enum `OAuthProvider`
+- Variaveis `LINKEDIN_CLIENT_ID` e `LINKEDIN_CLIENT_SECRET` ja no `.env.example`
+- Frontend tem 3 botoes sociais (Google, Facebook, Apple) — Facebook sera substituido por LinkedIn
+- App LinkedIn ja criado no LinkedIn Developers com credenciais disponiveis
+
+## Abordagem
+
+Minimal Delta — aproveitar 100% da infraestrutura existente. Nao refatorar codigo do Google, apenas replicar o padrao para LinkedIn.
+
+## Fluxo
+
+```
+1. Usuario clica botao LinkedIn
+2. Frontend chama GET /api/auth/linkedin/url
+3. Frontend redireciona o navegador para a URL retornada (LinkedIn consent)
+4. LinkedIn autentica e redireciona para GET /api/auth/linkedin/callback?code=...&state=...
+5. Backend valida state, troca code por tokens, cria/encontra usuario
+6. Backend salva session.userId no cookie
+7. Backend redireciona para FRONTEND_URL/auth/callback
+8. Frontend (pagina /auth/callback) chama GET /api/auth/me
+9. AuthContext recebe o usuario, navega para /app
+```
+
+Em caso de erro no passo 5-6, backend redireciona para `FRONTEND_URL/login?error=oauth_failed`.
+Se email ausente no profile, redireciona para `FRONTEND_URL/login?error=oauth_email_required`.
+
+## Mudancas
+
+### Backend
+
+#### 1. Validacao do provider `linkedin.ts`
+
+Arquivo existente: `backend/src/modules/auth/providers/linkedin.ts`
+
+Validar que:
+- Discovery URL `https://www.linkedin.com/oauth` funciona com `openid-client`
+- Credenciais `LINKEDIN_CLIENT_ID` / `LINKEDIN_CLIENT_SECRET` estao no `.env`
+- Callback URL no app LinkedIn matches `${APP_URL}/auth/linkedin/callback`
+
+Nenhuma mudanca estrutural necessaria — rotas, provider registry, e types ja estao prontos.
+
+#### 2. Tratamento de email ausente
+
+No fluxo de callback, apos obter o profile do LinkedIn, verificar se `profile.email` existe. Se nao existir, redirecionar para `/login?error=oauth_email_required` em vez de criar usuario sem email.
+
+### Frontend
+
+#### 3. `authService.ts` — nova funcao `getLinkedinAuthUrl`
+
+```ts
+export async function getLinkedinAuthUrl(): Promise<string> {
+  const response = await fetch(buildUrl("/api/auth/linkedin/url"), {
+    credentials: "include",
+  });
+  const payload = await parseResponse(response);
+  if (!response.ok) {
+    throw createError(payload, "Falha ao obter URL de autenticacao LinkedIn.");
+  }
+  return payload.url;
+}
+```
+
+#### 4. `RigthSide.tsx` e `RegisterSide.tsx` — botao LinkedIn
+
+Em ambos os componentes:
+- Importar `getLinkedinAuthUrl` do authService
+- Adicionar handler `handleLinkedinLogin` (mesmo padrao do `handleGoogleLogin`)
+- Substituir o botao Facebook (segundo no grid) por botao LinkedIn
+- Usar SVG inline para icone LinkedIn (mesmo padrao do botao Apple)
+- Adicionar `onClick={handleLinkedinLogin}`
+
+#### 5. `AuthCallback.tsx` — sem mudanca
+
+A pagina de callback e generica — chama `refreshUser()` e redireciona. Funciona para qualquer provider.
+
+## Testes
+
+### Integracao backend
+
+Estender `backend/tests/integration/routes/auth.routes.test.ts`:
+- `GET /api/auth/linkedin/url` — retorna URL de autorizacao valida
+- `GET /api/auth/linkedin/callback` — com state valido, processa login
+- `GET /api/auth/linkedin/callback` — com state invalido, redireciona com erro
+- Caso de email ausente — redireciona com `?error=oauth_email_required`
+
+### Testes frontend
+
+- `getLinkedinAuthUrl()` chama endpoint correto e retorna URL
+- Botao LinkedIn em `RigthSide.tsx` e `RegisterSide.tsx` dispara `handleLinkedinLogin`
+- `AuthCallback.tsx` continua funcionando (nao regressao)
+
+### Cobertura
+
+Manter niveis minimos de coverage exigidos pelo projeto.
+
+## Criterios de aceite
+
+- Login LinkedIn funciona end-to-end (clicar botao -> autenticar -> chegar no /app)
+- Conta criada automaticamente quando nao existe
+- Usuario fica autenticado no app apos login social (cookie de sessao persistido)
+- Email ausente no profile LinkedIn resulta em erro claro, nao em usuario sem email
+- Erros no OAuth redirecionam para /login com indicacao visual de falha
+- Funciona tanto na pagina de login quanto na de registro
+- Testes de integracao backend e frontend passando
+- Coverage minimo atendido
+
+## Fora de escopo
+
+- Login com Facebook ou Apple (botoes existem mas nao serao integrados agora)
+- Refresh de tokens OAuth
+- Linking de contas (usuario ja logado conectar LinkedIn)
+- Refatoracao do frontend para funcao generica de social auth

--- a/frontend/src/components/login/RegisterSide.tsx
+++ b/frontend/src/components/login/RegisterSide.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { register, getGoogleAuthUrl } from "@/services/authService";
+import { register, getGoogleAuthUrl, getLinkedinAuthUrl } from "@/services/authService";
 import { Image } from "@unpic/react";
 import { motion } from "framer-motion";
 import { ArrowLeft, Eye, EyeOff } from "lucide-react";
@@ -71,6 +71,18 @@ export default function RegisterSide() {
       const url = await getGoogleAuthUrl();
       window.location.href = url;
     } catch {
+      setIsLoading(false);
+    }
+  };
+
+  const handleLinkedinLogin = async () => {
+    setIsLoading(true);
+    setApiError("");
+    try {
+      const url = await getLinkedinAuthUrl();
+      window.location.href = url;
+    } catch (err: any) {
+      setApiError(err.message || "Erro ao iniciar login com LinkedIn.");
       setIsLoading(false);
     }
   };
@@ -230,8 +242,10 @@ export default function RegisterSide() {
           <button type="button" onClick={handleGoogleLogin} disabled={isLoading} className="flex justify-center items-center py-3 px-4 border border-gray-200 dark:border-neutral-800 rounded-xl bg-white/50 dark:bg-neutral-800/50 hover:bg-gray-50 dark:hover:bg-neutral-700/50 transition-all shadow-sm cursor-pointer disabled:opacity-50">
             <Image src="/google.png" alt="Google" width={20} height={20} className="object-contain" />
           </button>
-          <button type="button" disabled={isLoading} className="flex justify-center items-center py-3 px-4 border border-gray-200 dark:border-neutral-800 rounded-xl bg-white/50 dark:bg-neutral-800/50 hover:bg-gray-50 dark:hover:bg-neutral-700/50 transition-all shadow-sm cursor-pointer disabled:opacity-50">
-            <Image src="/facebook.png" alt="Facebook" width={20} height={20} className="object-contain" />
+          <button type="button" onClick={handleLinkedinLogin} disabled={isLoading} aria-label="LinkedIn" className="flex justify-center items-center py-3 px-4 border border-gray-200 dark:border-neutral-800 rounded-xl bg-white/50 dark:bg-neutral-800/50 hover:bg-gray-50 dark:hover:bg-neutral-700/50 transition-all shadow-sm cursor-pointer disabled:opacity-50">
+            <svg className="h-5 w-5 fill-[#0A66C2]" viewBox="0 0 24 24">
+              <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+            </svg>
           </button>
           <button type="button" disabled={isLoading} className="flex justify-center items-center py-3 px-4 border border-gray-200 dark:border-neutral-800 rounded-xl bg-white/50 dark:bg-neutral-800/50 hover:bg-gray-50 dark:hover:bg-neutral-700/50 transition-all shadow-sm cursor-pointer disabled:opacity-50">
             <svg className="h-5 w-5 fill-gray-900 dark:fill-white transition-colors" viewBox="0 0 24 24">

--- a/frontend/src/components/login/RigthSide.tsx
+++ b/frontend/src/components/login/RigthSide.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { login, getGoogleAuthUrl } from "@/services/authService";
+import { login, getGoogleAuthUrl, getLinkedinAuthUrl } from "@/services/authService";
 import { Image } from "@unpic/react";
 import { motion } from "framer-motion";
 import { ArrowLeft, Eye, EyeOff } from "lucide-react";
@@ -63,6 +63,18 @@ export default function RightSide() {
       window.location.href = url;
     } catch (err: any) {
       setApiError(err.message || "Erro ao iniciar login com Google.");
+      setIsLoading(false);
+    }
+  };
+
+  const handleLinkedinLogin = async () => {
+    setIsLoading(true);
+    setApiError("");
+    try {
+      const url = await getLinkedinAuthUrl();
+      window.location.href = url;
+    } catch (err: any) {
+      setApiError(err.message || "Erro ao iniciar login com LinkedIn.");
       setIsLoading(false);
     }
   };
@@ -233,8 +245,10 @@ export default function RightSide() {
           <button type="button" onClick={handleGoogleLogin} disabled={isLoading} className="flex justify-center items-center py-3 px-4 border border-gray-200 dark:border-neutral-800 rounded-xl bg-white/50 dark:bg-neutral-800/50 hover:bg-gray-50 dark:hover:bg-neutral-700/50 transition-all shadow-sm cursor-pointer disabled:opacity-50">
             <Image src="/google.png" alt="Google" width={20} height={20} className="object-contain" />
           </button>
-          <button type="button" disabled={isLoading} className="flex justify-center items-center py-3 px-4 border border-gray-200 dark:border-neutral-800 rounded-xl bg-white/50 dark:bg-neutral-800/50 hover:bg-gray-50 dark:hover:bg-neutral-700/50 transition-all shadow-sm cursor-pointer disabled:opacity-50">
-            <Image src="/facebook.png" alt="Facebook" width={20} height={20} className="object-contain" />
+          <button type="button" onClick={handleLinkedinLogin} disabled={isLoading} aria-label="LinkedIn" className="flex justify-center items-center py-3 px-4 border border-gray-200 dark:border-neutral-800 rounded-xl bg-white/50 dark:bg-neutral-800/50 hover:bg-gray-50 dark:hover:bg-neutral-700/50 transition-all shadow-sm cursor-pointer disabled:opacity-50">
+            <svg className="h-5 w-5 fill-[#0A66C2]" viewBox="0 0 24 24">
+              <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+            </svg>
           </button>
           <button type="button" disabled={isLoading} className="flex justify-center items-center py-3 px-4 border border-gray-200 dark:border-neutral-800 rounded-xl bg-white/50 dark:bg-neutral-800/50 hover:bg-gray-50 dark:hover:bg-neutral-700/50 transition-all shadow-sm cursor-pointer disabled:opacity-50">
             <svg className="h-5 w-5 fill-gray-900 dark:fill-white transition-colors" viewBox="0 0 24 24">

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -137,3 +137,17 @@ export async function getGoogleAuthUrl(): Promise<string> {
 
   return payload.url;
 }
+
+export async function getLinkedinAuthUrl(): Promise<string> {
+  const response = await fetch(buildUrl("/api/auth/linkedin/url"), {
+    credentials: "include",
+  });
+
+  const payload = await parseResponse(response);
+
+  if (!response.ok) {
+    throw createError(payload, "Falha ao obter URL de autenticacao LinkedIn.");
+  }
+
+  return payload.url;
+}

--- a/frontend/tests/unit/components/login/RegisterSide.test.tsx
+++ b/frontend/tests/unit/components/login/RegisterSide.test.tsx
@@ -3,8 +3,11 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockRegister = vi.fn();
+const mockGetLinkedinAuthUrl = vi.fn();
+
 vi.mock("@/services/authService", () => ({
   register: (...args: any[]) => mockRegister(...args),
+  getLinkedinAuthUrl: (...args: any[]) => mockGetLinkedinAuthUrl(...args),
 }));
 
 vi.mock("@unpic/react", () => ({
@@ -37,6 +40,7 @@ describe("RegisterSide", () => {
 
   beforeEach(() => {
     mockRegister.mockReset();
+    mockGetLinkedinAuthUrl.mockReset();
     Object.defineProperty(window, "location", {
       configurable: true,
       value: { href: "" },
@@ -146,6 +150,24 @@ describe("RegisterSide", () => {
       expect(emailInput).toBeDisabled();
       expect(telefoneInput).toBeDisabled();
       expect(passwordInput).toBeDisabled();
+    });
+  });
+
+  it("redireciona para LinkedIn OAuth ao clicar no botao LinkedIn", async () => {
+    mockGetLinkedinAuthUrl.mockResolvedValueOnce(
+      "https://www.linkedin.com/oauth/v2/authorization?state=abc"
+    );
+
+    render(<RegisterSide />);
+
+    const linkedinButton = screen.getByRole("button", { name: /linkedin/i });
+    fireEvent.click(linkedinButton);
+
+    await waitFor(() => {
+      expect(mockGetLinkedinAuthUrl).toHaveBeenCalled();
+      expect(window.location.href).toBe(
+        "https://www.linkedin.com/oauth/v2/authorization?state=abc"
+      );
     });
   });
 });

--- a/frontend/tests/unit/components/login/RigthSide.test.tsx
+++ b/frontend/tests/unit/components/login/RigthSide.test.tsx
@@ -4,9 +4,11 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockLogin = vi.fn();
+const mockGetLinkedinAuthUrl = vi.fn();
 
 vi.mock("@/services/authService", () => ({
   login: (...args: any[]) => mockLogin(...args),
+  getLinkedinAuthUrl: (...args: any[]) => mockGetLinkedinAuthUrl(...args),
 }));
 
 vi.mock("@unpic/react", () => ({
@@ -31,6 +33,7 @@ describe("RigthSide", () => {
 
   beforeEach(() => {
     mockLogin.mockReset();
+    mockGetLinkedinAuthUrl.mockReset();
     Object.defineProperty(window, "location", {
       configurable: true,
       value: { href: "" },
@@ -156,5 +159,23 @@ describe("RigthSide", () => {
   it("botão de esqueceu a senha está presente", () => {
     render(<RigthSide />);
     expect(screen.getByText(/esqueceu a senha/i)).toBeInTheDocument();
+  });
+
+  it("redireciona para LinkedIn OAuth ao clicar no botao LinkedIn", async () => {
+    mockGetLinkedinAuthUrl.mockResolvedValueOnce(
+      "https://www.linkedin.com/oauth/v2/authorization?state=abc"
+    );
+
+    render(<RigthSide />);
+
+    const linkedinButton = screen.getByRole("button", { name: /linkedin/i });
+    fireEvent.click(linkedinButton);
+
+    await waitFor(() => {
+      expect(mockGetLinkedinAuthUrl).toHaveBeenCalled();
+      expect(window.location.href).toBe(
+        "https://www.linkedin.com/oauth/v2/authorization?state=abc"
+      );
+    });
   });
 });

--- a/frontend/tests/unit/services/auth.service.test.tsx
+++ b/frontend/tests/unit/services/auth.service.test.tsx
@@ -296,4 +296,48 @@ describe("authService", () => {
       );
     });
   });
+
+  describe("getLinkedinAuthUrl", () => {
+    it("should return LinkedIn auth URL on success", async () => {
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({
+          jsonData: { url: "https://www.linkedin.com/oauth/v2/authorization?state=abc" },
+        })
+      );
+
+      const url = await auth.getLinkedinAuthUrl();
+
+      expect(url).toBe("https://www.linkedin.com/oauth/v2/authorization?state=abc");
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/api/auth/linkedin/url"),
+        expect.objectContaining({ credentials: "include" })
+      );
+    });
+
+    it("should throw error on failure with message", async () => {
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 500,
+          jsonData: { message: "Provider unavailable" },
+        })
+      );
+
+      await expect(auth.getLinkedinAuthUrl()).rejects.toThrow("Provider unavailable");
+    });
+
+    it("should throw error on failure without message", async () => {
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 500,
+          jsonData: {},
+        })
+      );
+
+      await expect(auth.getLinkedinAuthUrl()).rejects.toThrow(
+        "Falha ao obter URL de autenticacao LinkedIn."
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Descrição
Implementa o login social com LinkedIn (OAuth) no Painel Vagas. No backend, foi adicionado o provider LinkedIn com validação de email obrigatório. No frontend, o botão "Entrar com Facebook" foi substituído pelo botão "Entrar com LinkedIn" nas telas de login e registro, e a função `getLinkedinAuthUrl` foi adicionada ao authService. Testes foram atualizados para cobrir os novos fluxos e manter o threshold de 80% de cobertura.

## Linear link
https://linear.app/tatame/issue/PAV-6/login-social-linkedin-oauth

## Como foi testado
Testes unitários — Backend: 309/309 passando | Frontend: 149/153 (4 falhas pré-existentes em jobsService.test.ts)