### PR TITLE
docs: adiciona codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Responsaveis padrao para todos os diretorios do repositorio.
+* @Benevanio @hltav
+
+# Responsaveis por alteracoes dentro de /frontend.
+/frontend/** @lima300 @nayarakarinesilva


### PR DESCRIPTION
## O que foi feito

Adicionado o arquivo `.github/CODEOWNERS` para definir os responsáveis por revisão de código no repositório.

## Regras configuradas

- Alterações dentro de `/frontend` terão como responsáveis:
  - `@lima300`
  - `@nayarakarinesilva`

- Alterações nos demais diretórios terão como responsáveis:
  - `@Benevanio`
  - `@hltav`

## Objetivo

Automatizar a atribuição de reviewers nos PRs conforme a área modificada, facilitando o fluxo de revisão e garantindo que cada parte do projeto seja analisada pelas pessoas responsáveis.