### PR TITLE
feat(PAV-88): implementa preferência inicial de modalidade de vagas

### DIFF
--- a/backend/bruno/Users/Patch Preferences.bru
+++ b/backend/bruno/Users/Patch Preferences.bru
@@ -20,7 +20,7 @@ body:json {
     "searchLocation": "São Paulo, Brasil",
     "searchLanguage": "pt",
     "remoteOnly": true,
-    "jobTypes": ["full-time", "contract"],
+    "jobTypes": ["Remoto", "Híbrido"],
     "emailNotifications": false
   }
 }

--- a/backend/bruno/Users/Post Preferences.bru
+++ b/backend/bruno/Users/Post Preferences.bru
@@ -20,7 +20,7 @@ body:json {
     "searchLocation": "São Paulo, Brasil",
     "searchLanguage": "pt",
     "remoteOnly": true,
-    "jobTypes": ["full-time", "contract"],
+    "jobTypes": ["Remoto", "Híbrido"],
     "emailNotifications": false
   }
 }

--- a/backend/src/modules/users/schemas/user.schemas.ts
+++ b/backend/src/modules/users/schemas/user.schemas.ts
@@ -38,13 +38,15 @@ export const updateProfileSchema = z
 
 // ── Preferences ───────────────────────────────────────────────────────────────
 
+const jobTypePreferenceSchema = z.enum(["Remoto", "Híbrido", "Presencial"]);
+
 export const updatePreferencesSchema = z
   .object({
     keywords: z.array(z.string().min(1)).max(20),
     searchLocation: z.string().min(1).max(100).nullable(),
     searchLanguage: z.string().length(2).nullable(),
     remoteOnly: z.boolean(),
-    jobTypes: z.array(z.string().min(1)).max(10),
+    jobTypes: z.array(jobTypePreferenceSchema).max(3),
     emailNotifications: z.boolean(),
     careerChecklist: z
       .array(

--- a/frontend/src/domains/new_dashboard/NewDashboardPage.tsx
+++ b/frontend/src/domains/new_dashboard/NewDashboardPage.tsx
@@ -18,6 +18,7 @@ import { useUserDashboardData } from "./hooks/useUserDashboardData";
 import type {
   CareerChecklist,
   Job,
+  JobModelFilter,
   JobStatus,
   MatchSort,
   NewJob,
@@ -29,6 +30,11 @@ import {
   type ContinentFilter,
   type CountryFilter,
 } from "./utils/locationFilters";
+import {
+  getModelFilterFromJobTypes,
+  modelFilterMatchesJob,
+  modelFilterToApiFilter,
+} from "./utils/jobModelFilters";
 import { parseSearchKeywords } from "./utils/searchKeywords";
 
 function getSection(pathname: string) {
@@ -149,7 +155,7 @@ export default function NewDashboardPage() {
   const navigate = useNavigate();
 
   const [searchQuery, setSearchQuery] = useState("");
-  const [filterType, setFilterType] = useState("Todos");
+  const [filterType, setFilterType] = useState<JobModelFilter>("Todos");
   const [filterLevel, setFilterLevel] = useState("Todos");
   const [continentFilter, setContinentFilter] =
     useState<ContinentFilter>("Todos");
@@ -159,12 +165,14 @@ export default function NewDashboardPage() {
   const [isAddJobOpen, setIsAddJobOpen] = useState(false);
   const [toast, setToast] = useState("");
   const checklistSaveTimeout = useRef<number | null>(null);
+  const hasUserSelectedModelFilter = useRef(false);
   const showToast = useCallback((message: string) => setToast(message), []);
   const {
     userProfile,
     setUserProfile,
     searchPreferences,
     setSearchPreferences,
+    isLoadingUserData,
     isSavingProfile,
     isSavingPreferences,
     saveUserProfile,
@@ -195,6 +203,13 @@ export default function NewDashboardPage() {
         scoreJobWithTechnologies(job, userProfile.technologyExperiences),
       ),
     [recommendedJobs, userProfile.technologyExperiences],
+  );
+  const displayedRecommendedJobs = useMemo(
+    () =>
+      matchedRecommendedJobs.filter((job) =>
+        modelFilterMatchesJob(job, filterType),
+      ),
+    [filterType, matchedRecommendedJobs],
   );
   const selectedJob =
     [...matchedTrackedJobs, ...matchedRecommendedJobs].find(
@@ -230,11 +245,18 @@ export default function NewDashboardPage() {
   const handleSavePreferences = async (preferences: SearchPreferences) => {
     try {
       await saveSearchPreferences(preferences);
+      hasUserSelectedModelFilter.current = false;
+      setFilterType(getModelFilterFromJobTypes(preferences.jobTypes));
       showToast("Preferências de busca atualizadas.");
     } catch {
       // O hook já notificou a falha preservando as preferências editadas.
     }
   };
+
+  const handleFilterTypeChange = useCallback((value: JobModelFilter) => {
+    hasUserSelectedModelFilter.current = true;
+    setFilterType(value);
+  }, []);
 
   const handleCareerChecklistChange = useCallback(
     (careerChecklist: CareerChecklist[]) => {
@@ -313,9 +335,7 @@ export default function NewDashboardPage() {
     const typedKeywords = parseSearchKeywords(searchQuery);
     const filters = {
       ...(filterLevel !== "Todos" ? { level: filterLevel } : {}),
-      ...(filterType !== "Todos"
-        ? { type: filterType, model: filterType }
-        : {}),
+      ...modelFilterToApiFilter(filterType),
       ...(continentFilter !== "Todos" ? { continent: continentFilter } : {}),
       ...(countryFilter !== "Todos"
         ? { country: countryFilter, location: countryFilter }
@@ -346,6 +366,12 @@ export default function NewDashboardPage() {
     refreshRecommendations,
     searchQuery,
   ]);
+
+  useEffect(() => {
+    if (isLoadingUserData || hasUserSelectedModelFilter.current) return;
+
+    setFilterType(getModelFilterFromJobTypes(searchPreferences.jobTypes));
+  }, [isLoadingUserData, searchPreferences.jobTypes]);
 
   // Busca automática: dispara ao digitar (com debounce) ou ao trocar
   // qualquer filtro, sem precisar clicar em "Buscar vagas".
@@ -398,11 +424,11 @@ export default function NewDashboardPage() {
       case "vagas":
         return (
           <JobTab
-            jobs={matchedRecommendedJobs}
+            jobs={displayedRecommendedJobs}
             searchQuery={searchQuery}
             setSearchQuery={setSearchQuery}
             filterType={filterType}
-            setFilterType={setFilterType}
+            setFilterType={handleFilterTypeChange}
             filterLevel={filterLevel}
             setFilterLevel={setFilterLevel}
             continentFilter={continentFilter}

--- a/frontend/src/domains/new_dashboard/components/jobs/JobFilter.tsx
+++ b/frontend/src/domains/new_dashboard/components/jobs/JobFilter.tsx
@@ -1,6 +1,7 @@
 import { Search } from "lucide-react";
-import { jobLevels, jobTypes } from "../../constants";
-import type { MatchSort } from "../../types";
+import { jobLevels } from "../../constants";
+import type { JobModelFilter, MatchSort } from "../../types";
+import { jobModelFilterOptions } from "../../utils/jobModelFilters";
 import {
   continentOptions,
   countryOptions,
@@ -11,8 +12,8 @@ import {
 interface JobFilterProps {
   searchQuery: string;
   setSearchQuery: (value: string) => void;
-  filterType: string;
-  setFilterType: (value: string) => void;
+  filterType: JobModelFilter;
+  setFilterType: (value: JobModelFilter) => void;
   filterLevel: string;
   setFilterLevel: (value: string) => void;
   continentFilter: ContinentFilter;
@@ -51,13 +52,19 @@ export function JobFilter({
 
       <select
         value={filterType}
-        onChange={(event) => setFilterType(event.target.value)}
+        onChange={(event) =>
+          setFilterType(event.target.value as JobModelFilter)
+        }
         className="h-11 rounded-lg border border-input bg-background px-3 text-sm outline-none transition-colors focus:border-ring"
       >
         <option value="Todos">Modelo (Todos)</option>
-        {jobTypes.map((type) => (
-          <option key={type}>{type}</option>
-        ))}
+        {jobModelFilterOptions
+          .filter((option) => option.value !== "Todos")
+          .map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
       </select>
 
       <select

--- a/frontend/src/domains/new_dashboard/components/jobs/JobTab.tsx
+++ b/frontend/src/domains/new_dashboard/components/jobs/JobTab.tsx
@@ -1,9 +1,19 @@
 import { Search } from "lucide-react";
-import type { Job, JobStatus, MatchSort, SearchPreferences } from "../../types";
+import type {
+  Job,
+  JobModelFilter,
+  JobStatus,
+  MatchSort,
+  SearchPreferences,
+} from "../../types";
 import {
   type ContinentFilter,
   type CountryFilter,
 } from "../../utils/locationFilters";
+import {
+  getModelFilterFromJobTypes,
+  jobModelFilterOptions,
+} from "../../utils/jobModelFilters";
 import { JobFilter } from "./JobFilter";
 import { JobTable } from "./JobTable";
 
@@ -11,8 +21,8 @@ interface JobTabProps {
   jobs: Job[];
   searchQuery: string;
   setSearchQuery: (value: string) => void;
-  filterType: string;
-  setFilterType: (value: string) => void;
+  filterType: JobModelFilter;
+  setFilterType: (value: JobModelFilter) => void;
   filterLevel: string;
   setFilterLevel: (value: string) => void;
   continentFilter: ContinentFilter;
@@ -59,6 +69,13 @@ export function JobTab({
   onOpenJob,
   onStatusChange,
 }: JobTabProps) {
+  const preferredModelFilter = searchPreferences
+    ? getModelFilterFromJobTypes(searchPreferences.jobTypes)
+    : "Todos";
+  const preferredModelLabel = jobModelFilterOptions.find(
+    (option) => option.value === preferredModelFilter,
+  )?.label;
+
   return (
     <div className="mx-auto flex w-full max-w-[1680px] flex-col gap-6 px-6 py-8 lg:px-8">
       <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
@@ -97,10 +114,10 @@ export function JobTab({
         setMatchSort={setMatchSort}
       />
 
-      {searchPreferences?.remoteOnly && (
+      {preferredModelFilter !== "Todos" && preferredModelLabel && (
         <p className="text-sm font-semibold text-emerald-600">
-          • Filtro de busca ativo: Apenas oportunidades remotas habilitado nas
-          preferências.
+          • Preferência ativa: {preferredModelLabel.toLowerCase()} como padrão
+          nesta busca.
         </p>
       )}
 

--- a/frontend/src/domains/new_dashboard/components/profile/PreferencesForm.tsx
+++ b/frontend/src/domains/new_dashboard/components/profile/PreferencesForm.tsx
@@ -1,4 +1,9 @@
-import type { SearchPreferences } from "../../types";
+import type { JobModelFilter, SearchPreferences } from "../../types";
+import {
+  getJobTypesFromModelFilter,
+  getModelFilterFromJobTypes,
+  jobModelFilterOptions,
+} from "../../utils/jobModelFilters";
 
 interface PreferencesFormProps {
   searchPreferences: SearchPreferences;
@@ -13,6 +18,10 @@ export function PreferencesForm({
   isSaving = false,
   onSave,
 }: PreferencesFormProps) {
+  const preferredModelFilter = getModelFilterFromJobTypes(
+    searchPreferences.jobTypes,
+  );
+
   return (
     <section className="rounded-2xl border border-border bg-card p-6 shadow-sm">
       <h2 className="text-[18px] font-bold">Preferências de Carreira</h2>
@@ -43,24 +52,34 @@ export function PreferencesForm({
             />
           </label>
 
-          <div className="flex flex-col justify-center gap-3">
-            <label className="flex cursor-pointer select-none items-start gap-3 text-xs font-bold text-muted-foreground">
-              <input
-                type="checkbox"
-                checked={searchPreferences.remoteOnly}
-                onChange={(event) =>
+          <div className="flex flex-col justify-center gap-4">
+            <label>
+              <span className="mb-2 block text-xs font-bold uppercase text-muted-foreground">
+                Vagas Exibidas Inicialmente
+              </span>
+              <select
+                value={preferredModelFilter}
+                onChange={(event) => {
+                  const jobTypes = getJobTypesFromModelFilter(
+                    event.target.value as JobModelFilter,
+                  );
                   setSearchPreferences((current) => ({
                     ...current,
-                    remoteOnly: event.target.checked,
-                  }))
-                }
-                className="mt-0.5 h-4 w-4 rounded accent-primary"
-              />
-              <span>
-                <span className="block text-foreground">Apenas Oportunidades Remotas</span>
-                <span className="mt-1 block font-normal">
-                  Esconde vagas híbridas ou presenciais da listagem principal.
-                </span>
+                    jobTypes,
+                    remoteOnly:
+                      jobTypes.length === 1 && jobTypes[0] === "Remoto",
+                  }));
+                }}
+                className="h-10 w-full rounded-lg border border-input bg-card px-4 text-sm outline-none focus:border-ring"
+              >
+                {jobModelFilterOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              <span className="mt-2 block text-xs text-muted-foreground">
+                Define o filtro padrão aplicado automaticamente na tela de vagas.
               </span>
             </label>
 

--- a/frontend/src/domains/new_dashboard/constants/initialData.ts
+++ b/frontend/src/domains/new_dashboard/constants/initialData.ts
@@ -210,6 +210,7 @@ export const initialPreferences: SearchPreferences = {
   keywords: ["React", "Frontend", "Fullstack"],
   searchLocation: "São Paulo, SP",
   remoteOnly: true,
+  jobTypes: ["Remoto"],
   emailNotifications: true,
   careerChecklist: [],
 };

--- a/frontend/src/domains/new_dashboard/infrastructure/userDashboardApi.ts
+++ b/frontend/src/domains/new_dashboard/infrastructure/userDashboardApi.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { api } from "@/shared/lib/apiClient";
-import type { SearchPreferences, UserProfile } from "../types";
+import type { JobType, SearchPreferences, UserProfile } from "../types";
 import { initialPreferences, initialUser } from "../constants";
 
 const ApiUserProfileSchema = z.object({
@@ -27,7 +27,10 @@ const ApiSearchPreferencesSchema = z.object({
   searchLocation: z.string().nullable().optional(),
   searchLanguage: z.string().nullable().optional(),
   remoteOnly: z.boolean().nullable().optional(),
-  jobTypes: z.array(z.string()).nullable().optional(),
+  jobTypes: z
+    .array(z.enum(["Remoto", "Híbrido", "Presencial"]))
+    .nullable()
+    .optional(),
   emailNotifications: z.boolean().nullable().optional(),
   careerChecklist: z
     .array(
@@ -50,6 +53,20 @@ const ApiSearchPreferencesSchema = z.object({
 
 type ApiUserProfile = z.infer<typeof ApiUserProfileSchema>;
 type ApiSearchPreferences = z.infer<typeof ApiSearchPreferencesSchema>;
+
+function normalizePreferenceJobTypes(
+  jobTypes: JobType[] | null | undefined,
+  remoteOnly: boolean | null | undefined,
+) {
+  if (jobTypes && jobTypes.length > 0) {
+    return [...new Set(jobTypes)];
+  }
+
+  if (remoteOnly === true) return ["Remoto"];
+  if (remoteOnly === false) return [];
+
+  return initialPreferences.jobTypes;
+}
 
 function fallbackNameParts(displayName: string) {
   const [firstName = initialUser.firstName, ...rest] = displayName.split(" ");
@@ -115,6 +132,10 @@ export function toUserProfile(data: unknown): UserProfile {
 
 export function toSearchPreferences(data: unknown): SearchPreferences {
   const preferences = ApiSearchPreferencesSchema.parse(data);
+  const jobTypes = normalizePreferenceJobTypes(
+    preferences.jobTypes,
+    preferences.remoteOnly,
+  );
 
   return {
     keywords:
@@ -123,7 +144,10 @@ export function toSearchPreferences(data: unknown): SearchPreferences {
         : initialPreferences.keywords,
     searchLocation:
       preferences.searchLocation?.trim() || initialPreferences.searchLocation,
-    remoteOnly: preferences.remoteOnly ?? initialPreferences.remoteOnly,
+    remoteOnly:
+      preferences.remoteOnly ??
+      (jobTypes.length === 1 && jobTypes[0] === "Remoto"),
+    jobTypes,
     emailNotifications:
       preferences.emailNotifications ?? initialPreferences.emailNotifications,
     careerChecklist:
@@ -150,6 +174,7 @@ function toPreferencesPayload(preferences: SearchPreferences) {
     keywords: preferences.keywords,
     searchLocation: preferences.searchLocation || null,
     remoteOnly: preferences.remoteOnly,
+    jobTypes: preferences.jobTypes,
     emailNotifications: preferences.emailNotifications,
     careerChecklist: preferences.careerChecklist,
   };

--- a/frontend/src/domains/new_dashboard/types/job.ts
+++ b/frontend/src/domains/new_dashboard/types/job.ts
@@ -53,3 +53,9 @@ export type JobLevel = z.infer<typeof JobLevelSchema>;
 export type Job = z.infer<typeof JobSchema>;
 export type NewJob = z.infer<typeof NewJobSchema>;
 export type MatchSort = "default" | "desc" | "asc";
+export type JobModelFilter =
+  | "Todos"
+  | JobType
+  | "RemotoHibrido"
+  | "RemotoPresencial"
+  | "HibridoPresencial";

--- a/frontend/src/domains/new_dashboard/types/user.ts
+++ b/frontend/src/domains/new_dashboard/types/user.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { JobTypeSchema } from "./job";
 
 export const TechnologyExperienceSchema = z.object({
   name: z.string().min(1),
@@ -35,6 +36,7 @@ export const SearchPreferencesSchema = z.object({
   keywords: z.array(z.string()),
   searchLocation: z.string().min(1),
   remoteOnly: z.boolean(),
+  jobTypes: z.array(JobTypeSchema),
   emailNotifications: z.boolean(),
   careerChecklist: z.array(CareerChecklistSchema),
 });

--- a/frontend/src/domains/new_dashboard/utils/jobModelFilters.ts
+++ b/frontend/src/domains/new_dashboard/utils/jobModelFilters.ts
@@ -1,0 +1,60 @@
+import type { Job, JobModelFilter, JobType } from "../types";
+
+export const jobModelFilterOptions: Array<{
+  value: JobModelFilter;
+  label: string;
+  types: JobType[];
+}> = [
+  { value: "Todos", label: "Todas as vagas", types: [] },
+  { value: "Remoto", label: "Somente remotas", types: ["Remoto"] },
+  { value: "Híbrido", label: "Somente híbridas", types: ["Híbrido"] },
+  { value: "Presencial", label: "Somente presenciais", types: ["Presencial"] },
+  {
+    value: "RemotoHibrido",
+    label: "Remotas e híbridas",
+    types: ["Remoto", "Híbrido"],
+  },
+  {
+    value: "RemotoPresencial",
+    label: "Remotas e presenciais",
+    types: ["Remoto", "Presencial"],
+  },
+  {
+    value: "HibridoPresencial",
+    label: "Híbridas e presenciais",
+    types: ["Híbrido", "Presencial"],
+  },
+];
+
+export function getJobTypesFromModelFilter(filterType: JobModelFilter) {
+  return (
+    jobModelFilterOptions.find((option) => option.value === filterType)
+      ?.types ?? []
+  );
+}
+
+export function getModelFilterFromJobTypes(jobTypes: JobType[]) {
+  const normalized = [...new Set(jobTypes)].sort().join("|");
+
+  return (
+    jobModelFilterOptions.find(
+      (option) => [...option.types].sort().join("|") === normalized,
+    )?.value ?? "Todos"
+  );
+}
+
+export function modelFilterMatchesJob(job: Job, filterType: JobModelFilter) {
+  const jobTypes = getJobTypesFromModelFilter(filterType);
+  return jobTypes.length === 0 || jobTypes.includes(job.type);
+}
+
+export function modelFilterToApiFilter(filterType: JobModelFilter) {
+  const jobTypes = getJobTypesFromModelFilter(filterType);
+  if (jobTypes.length !== 1) return {};
+
+  const [type] = jobTypes;
+  return {
+    type,
+    model: type,
+  };
+}

--- a/frontend/tests/unit/new_dashboard/api.test.ts
+++ b/frontend/tests/unit/new_dashboard/api.test.ts
@@ -420,6 +420,7 @@ describe("new_dashboard api adapters", () => {
           keywords: ["React"],
           searchLocation: "Lisboa",
           remoteOnly: true,
+          jobTypes: ["Remoto"],
           emailNotifications: false,
           careerChecklist: [],
         },
@@ -473,6 +474,7 @@ describe("new_dashboard api adapters", () => {
           keywords: ["React"],
           searchLocation: "Brasil",
           remoteOnly: true,
+          jobTypes: ["Remoto"],
           emailNotifications: true,
           careerChecklist: [],
         },
@@ -494,6 +496,7 @@ describe("new_dashboard api adapters", () => {
       keywords: ["React"],
       searchLocation: "Brasil",
       remoteOnly: true,
+      jobTypes: ["Remoto"],
       emailNotifications: true,
       careerChecklist: [],
     });
@@ -509,6 +512,7 @@ describe("new_dashboard api adapters", () => {
       "/users/preferences",
       expect.objectContaining({
         searchLocation: "Brasil",
+        jobTypes: ["Remoto"],
         careerChecklist: [],
       }),
     );

--- a/frontend/tests/unit/new_dashboard/home.profile.test.tsx
+++ b/frontend/tests/unit/new_dashboard/home.profile.test.tsx
@@ -223,7 +223,9 @@ describe("new_dashboard home and profile components", () => {
     fireEvent.change(screen.getByLabelText(/localidade principal de busca/i), {
       target: { value: "Lisboa, Portugal" },
     });
-    fireEvent.click(screen.getByLabelText(/apenas oportunidades remotas/i));
+    fireEvent.change(screen.getByLabelText(/vagas exibidas inicialmente/i), {
+      target: { value: "RemotoHibrido" },
+    });
     fireEvent.click(
       screen.getByLabelText(/habilitar alertas de vagas no e-mail/i),
     );
@@ -235,6 +237,7 @@ describe("new_dashboard home and profile components", () => {
       expect.objectContaining({
         searchLocation: "Lisboa, Portugal",
         remoteOnly: false,
+        jobTypes: ["Remoto", "Híbrido"],
         emailNotifications: false,
       }),
     );

--- a/frontend/tests/unit/new_dashboard/page.test.tsx
+++ b/frontend/tests/unit/new_dashboard/page.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import NewDashboardPage from "@/domains/new_dashboard/NewDashboardPage";
@@ -141,6 +141,7 @@ describe("NewDashboardPage", () => {
         keywords: ["React"],
         searchLocation: "Brasil",
         remoteOnly: false,
+        jobTypes: [],
         emailNotifications: true,
         careerChecklist: [],
       },
@@ -210,6 +211,63 @@ describe("NewDashboardPage", () => {
       screen.getByRole("heading", { name: /vagas abertas recomendadas/i }),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /buscar vagas/i })).toBeInTheDocument();
+  });
+
+  it("usa apenas vagas remotas como padrão quando a preferência está ativa", async () => {
+    mockUseUserDashboardData.mockReturnValue({
+      ...mockUseUserDashboardData(),
+      searchPreferences: {
+        keywords: ["React"],
+        searchLocation: "Brasil",
+        remoteOnly: true,
+        jobTypes: ["Remoto"],
+        emailNotifications: true,
+        careerChecklist: [],
+      },
+    });
+    dashboardJobsState.recommendedJobs = [
+      {
+        id: "remote-job",
+        jobTitle: "Remote Node",
+        company: "Globex",
+        location: "Global",
+        salary: "A combinar",
+        type: "Remoto",
+        level: "Sênior",
+        matchScore: 91,
+        tags: ["Node.js"],
+        posted: "Hoje",
+        status: "saved",
+        jobLink: "https://example.com/remote",
+        source: "Gupy",
+        notes: "",
+      },
+      {
+        id: "onsite-job",
+        jobTitle: "Onsite Node",
+        company: "ACME",
+        location: "São Paulo",
+        salary: "A combinar",
+        type: "Presencial",
+        level: "Sênior",
+        matchScore: 88,
+        tags: ["Node.js"],
+        posted: "Hoje",
+        status: "saved",
+        jobLink: "https://example.com/onsite",
+        source: "LinkedIn",
+        notes: "",
+      },
+    ];
+
+    renderPage("/vagas");
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Somente remotas")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Remote Node")).toBeInTheDocument();
+    expect(screen.queryByText("Onsite Node")).not.toBeInTheDocument();
   });
 
   it("aciona a busca e paginação de vagas", () => {


### PR DESCRIPTION
- Substitui o checkbox de vagas remotas por um select de modalidade inicial no perfil.
- Persiste combinações de modalidade em jobTypes.
- Aplica a preferência automaticamente como filtro inicial na tela de vagas.
- Mantém compatibilidade com remoteOnly para dados antigos.