### PR TITLE
PAV-98: Remover link de Contato inativo do rodapé

### DIFF
--- a/frontend/src/domains/marketing/presentation/components/Footer.tsx
+++ b/frontend/src/domains/marketing/presentation/components/Footer.tsx
@@ -38,7 +38,6 @@ export function Footer() {
             <ul className="space-y-4 text-gray-500 dark:text-gray-400">
               <li><a href="#" className="hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors">Termos de Uso</a></li>
               <li><a href="#" className="hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors">Privacidade</a></li>
-              <li><a href="#" className="hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors">Contato</a></li>
             </ul>
           </div>
         </div>

--- a/frontend/tests/unit/components/Footer.test.tsx
+++ b/frontend/tests/unit/components/Footer.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Footer } from "../../../src/domains/marketing/presentation/components/Footer";
+
+describe("Footer", () => {
+  it("não exibe o link inativo de Contato", () => {
+    render(<Footer />);
+
+    expect(screen.queryByRole("link", { name: "Contato" })).toBeNull();
+  });
+
+  it("mantém os demais links da seção Legal", () => {
+    render(<Footer />);
+
+    expect(screen.getByRole("link", { name: "Termos de Uso" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Privacidade" })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Descrição
Remove o link "Contato" da seção Legal do rodapé da landing page de marketing (`Footer.tsx`). O link apontava para `href="#"`, sem destino real, e como não existe página/seção de Contato nem previsão de criá-la, ele foi removido em vez de implementado — o escopo original da PAV-98 foi ajustado para essa decisão. Também adiciona um teste unitário do `Footer` cobrindo a remoção do link e a permanência dos demais itens da seção Legal (Termos de Uso e Privacidade).

## Linear link
https://linear.app/tatame/issue/PAV-98/remover-link-de-contato-inativo-do-rodape

## Como foi testado
Testes unitários passando — Backend: 505/505 | Frontend: 282/282