### PR TITLE
Pedro/bugs melhorias

### DIFF
--- a/backend/src/modules/types/credentials.types.ts
+++ b/backend/src/modules/types/credentials.types.ts
@@ -1,11 +1,35 @@
 import z from "zod";
 
 export const RegisterSchema = z.object({
-  email: z.string().email("Email inválido"),
-  password: z.string().min(8, "Senha deve ter no mínimo 8 caracteres"),
-  name: z.string().min(1, "Nome é obrigatório").optional(),
-  phone: z.string().optional(),
-  cpf: z.string().optional(),
+  email: z
+    .string()
+    .email("Email inválido")
+    .max(254, "Email deve ter no máximo 254 caracteres"),
+  password: z
+    .string()
+    .min(8, "Senha deve ter no mínimo 8 caracteres")
+    .max(128, "Senha deve ter no máximo 128 caracteres"),
+  name: z
+    .string()
+    .min(1, "Nome é obrigatório")
+    .max(100, "Nome deve ter no máximo 100 caracteres")
+    .optional(),
+  phone: z
+    .string()
+    .max(16, "Telefone deve ter no máximo 15 dígitos")
+    .refine(
+      (value) => value.replace(/\D/g, "").length <= 15,
+      "Telefone deve ter no máximo 15 dígitos",
+    )
+    .optional(),
+  cpf: z
+    .string()
+    .max(14, "CPF deve ter no máximo 11 dígitos")
+    .refine(
+      (value) => value.replace(/\D/g, "").length <= 11,
+      "CPF deve ter no máximo 11 dígitos",
+    )
+    .optional(),
   technologies: z.array(z.string()).optional(),
   level: z.string().optional(),
 });

--- a/backend/tests/unit/modules/auth/credentials.service.test.ts
+++ b/backend/tests/unit/modules/auth/credentials.service.test.ts
@@ -101,17 +101,19 @@ describe("CredentialsService", () => {
       };
     });
     mocks.insertReturning.mockResolvedValue([mockUser]);
-    mocks.transaction.mockImplementation(async (callback) => callback({
-      insert: vi.fn(() => ({
-        values: mocks.insertValues.mockImplementation(() => ({
-          returning: mocks.insertReturning,
+    mocks.transaction.mockImplementation(async (callback) =>
+      callback({
+        insert: vi.fn(() => ({
+          values: mocks.insertValues.mockImplementation(() => ({
+            returning: mocks.insertReturning,
+          })),
         })),
-      })),
-      query: {
-        credentials: { findFirst: mocks.credentialsFindFirst },
-        users: { findFirst: mocks.usersFindFirst },
-      },
-    }));
+        query: {
+          credentials: { findFirst: mocks.credentialsFindFirst },
+          users: { findFirst: mocks.usersFindFirst },
+        },
+      }),
+    );
 
     // Define retornos seguros e limpos para evitar falhas colaterais
     mocks.credentialsFindFirst.mockResolvedValue(null);
@@ -175,6 +177,18 @@ describe("CredentialsService", () => {
     it("lança erro de validação para senha vazia (Zod)", async () => {
       await expect(
         service.register({ email: "ok@example.com", password: "" }),
+      ).rejects.toThrow();
+    });
+
+    it.each([
+      ["nome", { name: "a".repeat(101) }],
+      ["email", { email: `${"a".repeat(250)}@x.com` }],
+      ["telefone", { phone: "1".repeat(16) }],
+      ["senha", { password: "a".repeat(129) }],
+      ["CPF", { cpf: "1".repeat(12) }],
+    ])("rejeita %s acima do limite permitido", async (_field, override) => {
+      await expect(
+        service.register({ ...registerInput, ...override }),
       ).rejects.toThrow();
     });
 

--- a/frontend/src/app/AppRoutes.tsx
+++ b/frontend/src/app/AppRoutes.tsx
@@ -34,7 +34,14 @@ export function AppRoutes() {
 
   return (
     <Routes>
-      <Route path="/" element={<LandingPage />} />
+      <Route
+        path="/"
+        element={
+          <PublicRoute>
+            <LandingPage />
+          </PublicRoute>
+        }
+      />
       <Route path="/home" element={dashboardElement} />
       <Route path="/dashboard" element={dashboardElement} />
       <Route path="/vagas" element={dashboardElement} />

--- a/frontend/src/domains/auth/presentation/components/RegisterFormPanel.tsx
+++ b/frontend/src/domains/auth/presentation/components/RegisterFormPanel.tsx
@@ -30,6 +30,14 @@ const LEVEL_OPTIONS = [
   { value: "senior", label: "Sênior" },
 ];
 
+const REGISTER_LIMITS = {
+  name: 100,
+  email: 254,
+  phoneDigits: 15,
+  password: 128,
+  cpf: 14,
+} as const;
+
 function getErrorMessage(error: unknown, fallback: string) {
   return error instanceof Error && error.message ? error.message : fallback;
 }
@@ -163,8 +171,8 @@ export default function RegisterSide() {
     if (!password) {
       setPasswordError("O campo de senha é obrigatório.");
       isValid = false;
-    } else if (password.length < 6) {
-      setPasswordError("A senha precisa conter pelo menos 6 caracteres.");
+    } else if (password.length < 8) {
+      setPasswordError("A senha precisa conter pelo menos 8 caracteres.");
       isValid = false;
     }
 
@@ -196,7 +204,9 @@ export default function RegisterSide() {
         window.location.href = "/login?registered=true";
       } catch (error: unknown) {
         console.error("Erro no cadastro:", error);
-        setApiError(getErrorMessage(error, "Erro ao cadastrar. Tente novamente."));
+        setApiError(
+          getErrorMessage(error, "Erro ao cadastrar. Tente novamente."),
+        );
       } finally {
         setIsLoading(false);
       }
@@ -260,6 +270,7 @@ export default function RegisterSide() {
             type="text"
             value={nome}
             onChange={(e) => setNome(e.target.value)}
+            maxLength={REGISTER_LIMITS.name}
             placeholder="benevanio"
             disabled={isLoading}
             className={`w-full px-4 py-3.5 rounded-xl border bg-white/80 dark:bg-neutral-800/80 backdrop-blur-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-2 transition-all shadow-sm ${nomeError ? "border-red-500 focus:ring-red-500" : "border-gray-200 dark:border-neutral-700 focus:ring-blue-500 focus:border-transparent"} ${isLoading ? "opacity-50 cursor-not-allowed" : ""}`}
@@ -282,6 +293,7 @@ export default function RegisterSide() {
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
+            maxLength={REGISTER_LIMITS.email}
             placeholder="benevanio@dev.com.br"
             disabled={isLoading}
             className={`w-full px-4 py-3.5 rounded-xl border bg-white/80 dark:bg-neutral-800/80 backdrop-blur-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-2 transition-all shadow-sm ${emailError ? "border-red-500 focus:ring-red-500" : "border-gray-200 dark:border-neutral-700 focus:ring-blue-500 focus:border-transparent"} ${isLoading ? "opacity-50 cursor-not-allowed" : ""}`}
@@ -303,7 +315,15 @@ export default function RegisterSide() {
               international
               defaultCountry="BR"
               value={telefone}
-              onChange={setTelefone}
+              onChange={(value) => {
+                if (
+                  !value ||
+                  value.replace(/\D/g, "").length <= REGISTER_LIMITS.phoneDigits
+                ) {
+                  setTelefone(value);
+                }
+              }}
+              numberInputProps={{ maxLength: REGISTER_LIMITS.phoneDigits + 1 }}
               disabled={isLoading}
               className="w-full px-4 py-3.5 text-gray-900 dark:text-white bg-transparent focus:outline-none phone-input-custom"
               placeholder="(34) 23456-7890"
@@ -328,6 +348,7 @@ export default function RegisterSide() {
               type={showPassword ? "text" : "password"}
               value={password}
               onChange={(e) => setPassword(e.target.value)}
+              maxLength={REGISTER_LIMITS.password}
               placeholder="Ex: ••••••••••••"
               disabled={isLoading}
               className={`w-full px-4 py-3.5 rounded-xl border bg-white/80 dark:bg-neutral-800/80 backdrop-blur-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-2 transition-all shadow-sm ${passwordError ? "border-red-500 focus:ring-red-500" : "border-gray-200 dark:border-neutral-700 focus:ring-blue-500 focus:border-transparent"} ${isLoading ? "opacity-50 cursor-not-allowed" : ""}`}
@@ -366,6 +387,7 @@ export default function RegisterSide() {
             type="text"
             value={cpf}
             onChange={(e) => setCpf(formatCpf(e.target.value))}
+            maxLength={REGISTER_LIMITS.cpf}
             placeholder="091.000.000-00"
             disabled={isLoading}
             className={`w-full px-4 py-3.5 rounded-xl border bg-white/80 dark:bg-neutral-800/80 backdrop-blur-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-2 transition-all shadow-sm ${cpfError ? "border-red-500 focus:ring-red-500" : "border-gray-200 dark:border-neutral-700 focus:ring-blue-500 focus:border-transparent"} ${isLoading ? "opacity-50 cursor-not-allowed" : ""}`}

--- a/frontend/src/domains/jobs/presentation/components/JobsFiltersCard.tsx
+++ b/frontend/src/domains/jobs/presentation/components/JobsFiltersCard.tsx
@@ -115,6 +115,7 @@ export function JobsFiltersCard({
               <Input
                 value={searchTerm}
                 onChange={(event) => setSearchTerm(event.target.value)}
+                maxLength={100}
                 className="h-14 w-full rounded-2xl border border-slate-300 bg-white pl-11 pr-14 text-base text-slate-900 placeholder:text-slate-500 focus-visible:ring-[#14AE5C]/40 dark:border-[#35506f] dark:bg-[#091224] dark:text-slate-100 dark:placeholder:text-slate-400"
                 placeholder="Buscar por título, empresa, local ou link"
               />
@@ -183,11 +184,12 @@ export function JobsFiltersCard({
                 selectedFilters.map((filter) => (
                   <Badge
                     key={filter}
-                    className="gap-1.5 rounded-full border border-[#14AE5C]/30 bg-[#14AE5C]/12 px-2 py-1 text-xs font-semibold text-[#0c6b35] dark:text-[#8df0af]"
+                    title={filter}
+                    className="max-w-full gap-1.5 rounded-full border border-[#14AE5C]/30 bg-[#14AE5C]/12 px-2 py-1 text-xs font-semibold text-[#0c6b35] dark:text-[#8df0af]"
                   >
                     <FiCheck className="h-3 w-3" />
                     <FiTag className="h-3 w-3" />
-                    <span>{filter}</span>
+                    <span className="max-w-48 truncate">{filter}</span>
                     <button
                       type="button"
                       aria-label={`Remover filtro ${filter}`}

--- a/frontend/src/domains/jobs/presentation/components/KeywordsModal.tsx
+++ b/frontend/src/domains/jobs/presentation/components/KeywordsModal.tsx
@@ -1,9 +1,18 @@
-import { fetchKeywords, saveKeywords } from "@/domains/jobs/infrastructure/jobsApi";
+import {
+  fetchKeywords,
+  saveKeywords,
+} from "@/domains/jobs/infrastructure/jobsApi";
 import { X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/shared/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/shared/ui/card";
 import { Input } from "@/shared/ui/input";
 
 interface KeywordsModalProps {
@@ -61,7 +70,8 @@ export function KeywordsModal({ onClose }: KeywordsModalProps) {
         <CardHeader>
           <CardTitle>Gerenciar filtros</CardTitle>
           <CardDescription>
-            Adicione ou remova as palavras-chave usadas na busca e nos filtros de vagas.
+            Adicione ou remova as palavras-chave usadas na busca e nos filtros
+            de vagas.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -71,6 +81,7 @@ export function KeywordsModal({ onClose }: KeywordsModalProps) {
               aria-label="Nova keyword ou filtro"
               value={newKeyword}
               onChange={(e) => setNewKeyword(e.target.value)}
+              maxLength={100}
               onKeyDown={(e) => e.key === "Enter" && handleAddKeyword()}
             />
             <Button onClick={handleAddKeyword} disabled={isLoading || isSaving}>
@@ -80,14 +91,25 @@ export function KeywordsModal({ onClose }: KeywordsModalProps) {
 
           <div className="flex flex-wrap gap-2 p-4 border rounded-md bg-muted/20">
             {isLoading ? (
-              <p className="text-sm text-muted-foreground italic">Carregando keywords...</p>
+              <p className="text-sm text-muted-foreground italic">
+                Carregando keywords...
+              </p>
             ) : keywords.length === 0 ? (
-              <p className="text-sm text-muted-foreground italic">Nenhuma keyword cadastrada.</p>
+              <p className="text-sm text-muted-foreground italic">
+                Nenhuma keyword cadastrada.
+              </p>
             ) : (
               keywords.map((kw) => (
-                <Badge key={kw} variant="secondary" className="pl-3 pr-1 gap-1">
-                  {kw}
+                <Badge
+                  key={kw}
+                  variant="secondary"
+                  title={kw}
+                  className="max-w-full pl-3 pr-1 gap-1"
+                >
+                  <span className="max-w-72 truncate">{kw}</span>
                   <button
+                    type="button"
+                    aria-label={`Remover keyword ${kw}`}
                     onClick={() => handleRemoveKeyword(kw)}
                     className="hover:bg-red-500/50 rounded-full p-0.5"
                   >

--- a/frontend/src/domains/marketing/presentation/components/Footer.tsx
+++ b/frontend/src/domains/marketing/presentation/components/Footer.tsx
@@ -8,45 +8,102 @@ export function Footer() {
       <div className="max-w-7xl mx-auto px-6 md:px-12">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-12 mb-16">
           <div className="md:col-span-2">
-
             <div className="flex items-center text-[30px] mb-6">
               <span className="text-blue-500 font-light">&lt;</span>
-              Cand<span className="text-amber-500">!</span>Date<span className="text-purple-500">!</span>
+              Cand<span className="text-amber-500">!</span>Date
+              <span className="text-purple-500">!</span>
               <span className="text-blue-500 font-light">&gt;</span>
             </div>
 
             <p className="text-gray-500 dark:text-gray-400 max-w-sm mb-8 leading-relaxed">
-              Automatizando a busca por vagas de TI para desenvolvedores do mundo inteiro. Encontre o emprego ideal sem perder horas pesquisando.
+              Automatizando a busca por vagas de TI para desenvolvedores do
+              mundo inteiro. Encontre o emprego ideal sem perder horas
+              pesquisando.
             </p>
             <div className="flex items-center gap-4 text-gray-400 dark:text-gray-500">
-              <a href="https://github.com/Cla-Code-Community/candidate" target="_blank" rel="noopener noreferrer" className="hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors"><Github size={20} /></a>
+              <a
+                href="https://github.com/Cla-Code-Community/candidate"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Repositório do projeto no GitHub"
+                className="hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors"
+              >
+                <Github size={20} />
+              </a>
             </div>
           </div>
 
           <div>
-            <h4 className="text-gray-900 dark:text-white font-semibold mb-6">Produto</h4>
+            <h4 className="text-gray-900 dark:text-white font-semibold mb-6">
+              Produto
+            </h4>
             <ul className="space-y-4 text-gray-500 dark:text-gray-400">
-              <li><a href="#features" className="hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors">Funcionalidades</a></li>
-              <li><a href="#time" className="hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors">Time</a></li>
-              <li><a href="#how-it-works" className="hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors">Como Funciona</a></li>
-              <li><a href="#status" className="hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors">Status</a></li>
+              <li>
+                <a
+                  href="#features"
+                  className="hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors"
+                >
+                  Funcionalidades
+                </a>
+              </li>
+              <li>
+                <a
+                  href="#time"
+                  className="hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors"
+                >
+                  Time
+                </a>
+              </li>
+              <li>
+                <a
+                  href="#how-it-works"
+                  className="hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors"
+                >
+                  Como Funciona
+                </a>
+              </li>
+              <li>
+                <a
+                  href="#status"
+                  className="hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors"
+                >
+                  Status
+                </a>
+              </li>
             </ul>
           </div>
 
           <div>
-            <h4 className="text-gray-900 dark:text-white font-semibold mb-6">Legal</h4>
+            <h4 className="text-gray-900 dark:text-white font-semibold mb-6">
+              Legal
+            </h4>
             <ul className="space-y-4 text-gray-500 dark:text-gray-400">
-              <li><a href="#" className="hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors">Termos de Uso</a></li>
-              <li><a href="#" className="hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors">Privacidade</a></li>
+              <li>
+                <a
+                  href="#"
+                  className="hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors"
+                >
+                  Termos de Uso
+                </a>
+              </li>
+              <li>
+                <a
+                  href="#"
+                  className="hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors"
+                >
+                  Privacidade
+                </a>
+              </li>
             </ul>
           </div>
         </div>
 
         <div className="pt-8 border-t border-gray-200 dark:border-white/10 flex flex-col md:flex-row items-center justify-between gap-4 text-sm text-gray-400 dark:text-gray-500">
-          <p>&copy; {new Date().getFullYear()} Painel de Vagas. Todos os direitos reservados.</p>
-          <div className="flex gap-6">
-
-          </div>
+          <p>
+            &copy; {new Date().getFullYear()} Painel de Vagas. Todos os direitos
+            reservados.
+          </p>
+          <div className="flex gap-6"></div>
         </div>
       </div>
     </footer>

--- a/frontend/src/domains/marketing/presentation/components/TeamSection.tsx
+++ b/frontend/src/domains/marketing/presentation/components/TeamSection.tsx
@@ -1,53 +1,65 @@
-import { useEffect, useState } from 'react';
-import { Autoplay, Pagination } from 'swiper/modules';
-import { Swiper, SwiperSlide } from 'swiper/react';
+import { useEffect, useState } from "react";
+import { Autoplay, Pagination } from "swiper/modules";
+import { Swiper, SwiperSlide } from "swiper/react";
 
-import { Github } from 'lucide-react';
-import 'swiper/css';
-import 'swiper/css/pagination';
+import { Github } from "lucide-react";
+import "swiper/css";
+import "swiper/css/pagination";
 
 interface Contributor {
   id: number;
   login: string;
+  name?: string;
   avatar_url: string;
   html_url: string;
   contributions: number;
   type: string;
 }
 
+const CONTRIBUTOR_NAMES: Record<string, string> = {
+  benevanio: "Benevanio",
+  pedrolucas1337: "Pedro Lucas",
+  thalitat: "Thalita",
+  jeremiassnts: "Jeremias Santos",
+};
+
 const INITIAL_TEAM: Contributor[] = [
   {
     id: 1,
     login: "Benevanio",
+    name: CONTRIBUTOR_NAMES.benevanio,
     avatar_url: "https://github.com/Benevanio.png",
     html_url: "https://github.com/Benevanio",
     contributions: 188,
-    type: "User"
+    type: "User",
   },
   {
     id: 104951475,
     login: "PedroLucas1337",
+    name: CONTRIBUTOR_NAMES.pedrolucas1337,
     avatar_url: "https://github.com/PedroLucas1337.png",
     html_url: "https://github.com/PedroLucas1337",
     contributions: 0,
-    type: "User"
+    type: "User",
   },
   {
     id: 110640572,
     login: "thalitat",
+    name: CONTRIBUTOR_NAMES.thalitat,
     avatar_url: "https://avatars.githubusercontent.com/u/110640572?v=4",
     html_url: "https://github.com/thalitat",
     contributions: 0,
-    type: "User"
+    type: "User",
   },
   {
     id: 999999998,
     login: "jeremiassnts",
+    name: CONTRIBUTOR_NAMES.jeremiassnts,
     avatar_url: "https://github.com/jeremiassnts.png",
     html_url: "https://github.com/jeremiassnts",
     contributions: 0,
-    type: "User"
-  }
+    type: "User",
+  },
 ];
 
 export default function TeamSection() {
@@ -59,75 +71,83 @@ export default function TeamSection() {
   useEffect(() => {
     fetch(`https://api.github.com/repos/${OWNER}/${REPO}/contributors`, {
       headers: {
-        Accept: 'application/vnd.github.v3+json',
-      }
+        Accept: "application/vnd.github.v3+json",
+      },
     })
       .then((res) => {
         if (!res.ok) throw new Error(`Erro HTTP: ${res.status}`);
         return res.json();
       })
-      .then((data: unknown) => {
+      .then(async (data: unknown) => {
         if (!Array.isArray(data)) return;
 
         const realUsers = (data as Contributor[])
-          .filter(user => user.type === 'User')
-          .map(user => {
+          .filter((user) => user.type === "User")
+          .map((user) => {
             const login = user.login.toLowerCase();
+            const name = CONTRIBUTOR_NAMES[login];
 
             if (login === "pedrolucas1337") {
               return {
                 ...user,
-                avatar_url: "https://github.com/PedroLucas1337.png"
+                name,
+                avatar_url: "https://github.com/PedroLucas1337.png",
               };
             }
 
             if (login === "thalitat") {
               return {
                 ...user,
-                avatar_url: "https://avatars.githubusercontent.com/u/110640572?v=4"
+                name,
+                avatar_url:
+                  "https://avatars.githubusercontent.com/u/110640572?v=4",
               };
             }
 
             if (login === "jeremiassnts") {
               return {
                 ...user,
-                avatar_url: "https://github.com/jeremiassnts.png"
+                name,
+                avatar_url: "https://github.com/jeremiassnts.png",
               };
             }
 
-            return user;
+            return { ...user, ...(name ? { name } : {}) };
           });
 
         const fixedMembers: Contributor[] = [
           {
             id: 104951475,
             login: "PedroLucas1337",
+            name: CONTRIBUTOR_NAMES.pedrolucas1337,
             avatar_url: "https://github.com/PedroLucas1337.png",
             html_url: "https://github.com/PedroLucas1337",
             contributions: 0,
-            type: "User"
+            type: "User",
           },
           {
             id: 110640572,
             login: "thalitat",
+            name: CONTRIBUTOR_NAMES.thalitat,
             avatar_url: "https://avatars.githubusercontent.com/u/110640572?v=4",
             html_url: "https://github.com/thalitat",
             contributions: 0,
-            type: "User"
+            type: "User",
           },
           {
             id: 999999998,
             login: "jeremiassnts",
+            name: CONTRIBUTOR_NAMES.jeremiassnts,
             avatar_url: "https://github.com/jeremiassnts.png",
             html_url: "https://github.com/jeremiassnts",
             contributions: 0,
-            type: "User"
-          }
+            type: "User",
+          },
         ];
 
-        fixedMembers.forEach(member => {
+        fixedMembers.forEach((member) => {
           const exists = realUsers.some(
-            user => user.login.toLowerCase() === member.login.toLowerCase()
+            (user) => user.login.toLowerCase() === member.login.toLowerCase(),
           );
 
           if (!exists) {
@@ -139,17 +159,51 @@ export default function TeamSection() {
 
         const unique = merged.filter(
           (user, index, self) =>
-            index === self.findIndex(
-              u => u.login.toLowerCase() === user.login.toLowerCase()
-            )
+            index ===
+            self.findIndex(
+              (u) => u.login.toLowerCase() === user.login.toLowerCase(),
+            ),
         );
 
-        setContributors(unique);
+        const contributorsWithNames = await Promise.all(
+          unique.map(async (user) => {
+            if (user.name) {
+              return user;
+            }
+
+            try {
+              const response = await fetch(
+                `https://api.github.com/users/${user.login}`,
+                {
+                  headers: {
+                    Accept: "application/vnd.github.v3+json",
+                  },
+                },
+              );
+
+              if (!response.ok) {
+                return user;
+              }
+
+              const profile = (await response.json()) as { name?: unknown };
+              const name =
+                typeof profile.name === "string" && profile.name.trim()
+                  ? profile.name.trim()
+                  : user.login;
+
+              return { ...user, name };
+            } catch {
+              return user;
+            }
+          }),
+        );
+
+        setContributors(contributorsWithNames);
       })
       .catch((err) => {
         console.warn(
           "GitHub API offline ou limitada. Mantendo lista local:",
-          err.message
+          err.message,
         );
       });
   }, []);
@@ -201,7 +255,6 @@ export default function TeamSection() {
             {contributors.map((user) => (
               <SwiperSlide key={user.id} className="h-full inline-block">
                 <div className="flex flex-col items-center p-6 border border-gray-100 dark:border-zinc-800/80 rounded-2xl text-center bg-white dark:bg-zinc-900/40 backdrop-blur-sm shadow-sm hover:shadow-md transition-all duration-300 min-h-[260px] h-full justify-between">
-                  
                   <div className="flex flex-col items-center w-full">
                     <img
                       src={user.avatar_url}
@@ -210,19 +263,22 @@ export default function TeamSection() {
                     />
 
                     <h4 className="font-semibold text-lg text-gray-900 dark:text-zinc-100 mb-1 truncate w-full">
-                      {user.login}
+                      {user.name || user.login}
                     </h4>
 
-                    <p className="text-xs font-medium text-gray-400 dark:text-zinc-500 mb-4">
+                    <p className="mb-2 max-w-full truncate text-xs text-gray-500 dark:text-zinc-400">
+                      @{user.login}
+                    </p>
+                    <p className="mb-4 text-xs font-medium text-gray-400 dark:text-zinc-500">
                       {user.login.toLowerCase() === "benevanio"
                         ? "Founder & Backend Dev"
                         : user.login.toLowerCase() === "pedrolucas1337"
-                        ? "QA"
-                        : user.login.toLowerCase() === "thalitat"
-                        ? "UX/UI Designer"
-                        : user.login.toLowerCase() === "jeremiassnts"
-                        ? "Engenheiro de Software Senior"
-                        : `${user.contributions} ${user.contributions === 1 ? 'commit' : 'commits'}`}
+                          ? "QA"
+                          : user.login.toLowerCase() === "thalitat"
+                            ? "UX/UI Designer"
+                            : user.login.toLowerCase() === "jeremiassnts"
+                              ? "Engenheiro de Software Senior"
+                              : `${user.contributions} ${user.contributions === 1 ? "commit" : "commits"}`}
                     </p>
                   </div>
 

--- a/frontend/src/domains/marketing/presentation/components/TeamSection.tsx
+++ b/frontend/src/domains/marketing/presentation/components/TeamSection.tsx
@@ -10,24 +10,40 @@ interface Contributor {
   id: number;
   login: string;
   name?: string;
+  role?: string;
   avatar_url: string;
   html_url: string;
   contributions: number;
   type: string;
 }
 
-const CONTRIBUTOR_NAMES: Record<string, string> = {
-  benevanio: "Benevanio",
-  pedrolucas1337: "Pedro Lucas",
-  thalitat: "Thalita",
-  jeremiassnts: "Jeremias Santos",
+const CONTRIBUTOR_DETAILS: Record<
+  string,
+  Pick<Contributor, "name" | "role">
+> = {
+  benevanio: {
+    name: "Benevanio",
+    role: "Founder & Backend Dev",
+  },
+  pedrolucas1337: {
+    name: "Pedro Lucas",
+    role: "QA",
+  },
+  thalitat: {
+    name: "Thalita",
+    role: "UX/UI Designer",
+  },
+  jeremiassnts: {
+    name: "Jeremias Santos",
+    role: "Engenheiro de Software Sênior",
+  },
 };
 
 const INITIAL_TEAM: Contributor[] = [
   {
     id: 1,
     login: "Benevanio",
-    name: CONTRIBUTOR_NAMES.benevanio,
+    ...CONTRIBUTOR_DETAILS.benevanio,
     avatar_url: "https://github.com/Benevanio.png",
     html_url: "https://github.com/Benevanio",
     contributions: 188,
@@ -36,7 +52,7 @@ const INITIAL_TEAM: Contributor[] = [
   {
     id: 104951475,
     login: "PedroLucas1337",
-    name: CONTRIBUTOR_NAMES.pedrolucas1337,
+    ...CONTRIBUTOR_DETAILS.pedrolucas1337,
     avatar_url: "https://github.com/PedroLucas1337.png",
     html_url: "https://github.com/PedroLucas1337",
     contributions: 0,
@@ -45,7 +61,7 @@ const INITIAL_TEAM: Contributor[] = [
   {
     id: 110640572,
     login: "thalitat",
-    name: CONTRIBUTOR_NAMES.thalitat,
+    ...CONTRIBUTOR_DETAILS.thalitat,
     avatar_url: "https://avatars.githubusercontent.com/u/110640572?v=4",
     html_url: "https://github.com/thalitat",
     contributions: 0,
@@ -54,7 +70,7 @@ const INITIAL_TEAM: Contributor[] = [
   {
     id: 999999998,
     login: "jeremiassnts",
-    name: CONTRIBUTOR_NAMES.jeremiassnts,
+    ...CONTRIBUTOR_DETAILS.jeremiassnts,
     avatar_url: "https://github.com/jeremiassnts.png",
     html_url: "https://github.com/jeremiassnts",
     contributions: 0,
@@ -85,12 +101,12 @@ export default function TeamSection() {
           .filter((user) => user.type === "User")
           .map((user) => {
             const login = user.login.toLowerCase();
-            const name = CONTRIBUTOR_NAMES[login];
+            const details = CONTRIBUTOR_DETAILS[login];
 
             if (login === "pedrolucas1337") {
               return {
                 ...user,
-                name,
+                ...details,
                 avatar_url: "https://github.com/PedroLucas1337.png",
               };
             }
@@ -98,7 +114,7 @@ export default function TeamSection() {
             if (login === "thalitat") {
               return {
                 ...user,
-                name,
+                ...details,
                 avatar_url:
                   "https://avatars.githubusercontent.com/u/110640572?v=4",
               };
@@ -107,19 +123,19 @@ export default function TeamSection() {
             if (login === "jeremiassnts") {
               return {
                 ...user,
-                name,
+                ...details,
                 avatar_url: "https://github.com/jeremiassnts.png",
               };
             }
 
-            return { ...user, ...(name ? { name } : {}) };
+            return { ...user, ...details };
           });
 
         const fixedMembers: Contributor[] = [
           {
             id: 104951475,
             login: "PedroLucas1337",
-            name: CONTRIBUTOR_NAMES.pedrolucas1337,
+            ...CONTRIBUTOR_DETAILS.pedrolucas1337,
             avatar_url: "https://github.com/PedroLucas1337.png",
             html_url: "https://github.com/PedroLucas1337",
             contributions: 0,
@@ -128,7 +144,7 @@ export default function TeamSection() {
           {
             id: 110640572,
             login: "thalitat",
-            name: CONTRIBUTOR_NAMES.thalitat,
+            ...CONTRIBUTOR_DETAILS.thalitat,
             avatar_url: "https://avatars.githubusercontent.com/u/110640572?v=4",
             html_url: "https://github.com/thalitat",
             contributions: 0,
@@ -137,7 +153,7 @@ export default function TeamSection() {
           {
             id: 999999998,
             login: "jeremiassnts",
-            name: CONTRIBUTOR_NAMES.jeremiassnts,
+            ...CONTRIBUTOR_DETAILS.jeremiassnts,
             avatar_url: "https://github.com/jeremiassnts.png",
             html_url: "https://github.com/jeremiassnts",
             contributions: 0,
@@ -155,7 +171,7 @@ export default function TeamSection() {
           }
         });
 
-        const merged = [...INITIAL_TEAM, ...realUsers];
+        const merged = [...realUsers, ...INITIAL_TEAM];
 
         const unique = merged.filter(
           (user, index, self) =>
@@ -269,17 +285,17 @@ export default function TeamSection() {
                     <p className="mb-2 max-w-full truncate text-xs text-gray-500 dark:text-zinc-400">
                       @{user.login}
                     </p>
-                    <p className="mb-4 text-xs font-medium text-gray-400 dark:text-zinc-500">
-                      {user.login.toLowerCase() === "benevanio"
-                        ? "Founder & Backend Dev"
-                        : user.login.toLowerCase() === "pedrolucas1337"
-                          ? "QA"
-                          : user.login.toLowerCase() === "thalitat"
-                            ? "UX/UI Designer"
-                            : user.login.toLowerCase() === "jeremiassnts"
-                              ? "Engenheiro de Software Senior"
-                              : `${user.contributions} ${user.contributions === 1 ? "commit" : "commits"}`}
+                    <p className="text-xs font-medium text-gray-500 dark:text-zinc-400">
+                      {user.role || "Contribuidor(a) open source"}
                     </p>
+                    <div className="mb-4 min-h-4 text-xs font-medium text-gray-400 dark:text-zinc-500">
+                      {user.contributions > 0 ? (
+                        <>
+                          {user.contributions}{" "}
+                          {user.contributions === 1 ? "commit" : "commits"}
+                        </>
+                      ) : null}
+                    </div>
                   </div>
 
                   <a

--- a/frontend/src/domains/new_dashboard/components/jobs/JobFilter.tsx
+++ b/frontend/src/domains/new_dashboard/components/jobs/JobFilter.tsx
@@ -45,6 +45,7 @@ export function JobFilter({
         <input
           value={searchQuery}
           onChange={(event) => setSearchQuery(event.target.value)}
+          maxLength={100}
           placeholder="Buscar por cargo, empresa ou keywords..."
           className="h-11 w-full rounded-lg border border-input bg-background pl-10 pr-3 text-sm outline-none transition-colors focus:border-ring"
         />

--- a/frontend/tests/unit/app/AppRoutes.test.tsx
+++ b/frontend/tests/unit/app/AppRoutes.test.tsx
@@ -73,6 +73,19 @@ describe("AppRoutes", () => {
     expect(screen.getByText("Landing route")).toBeInTheDocument();
   });
 
+  it("redireciona usuário autenticado da rota inicial para home", () => {
+    authState.value = {
+      user: { id: "1", email: "otavio@example.com" },
+      isLoading: false,
+    };
+
+    renderRoute("/");
+
+    expect(screen.getByText("Dashboard shell")).toBeInTheDocument();
+    expect(screen.getByText("New dashboard route")).toBeInTheDocument();
+    expect(screen.queryByText("Landing route")).not.toBeInTheDocument();
+  });
+
   it("mostra loading em rota protegida enquanto a sessão está carregando", () => {
     authState.value = {
       user: null,

--- a/frontend/tests/unit/components/Footer.test.tsx
+++ b/frontend/tests/unit/components/Footer.test.tsx
@@ -12,7 +12,23 @@ describe("Footer", () => {
   it("mantém os demais links da seção Legal", () => {
     render(<Footer />);
 
-    expect(screen.getByRole("link", { name: "Termos de Uso" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Privacidade" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Termos de Uso" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Privacidade" }),
+    ).toBeInTheDocument();
+  });
+
+  it("direciona o ícone do GitHub para o repositório do projeto", () => {
+    render(<Footer />);
+
+    expect(
+      screen.getByRole("link", { name: /repositório do projeto no github/i }),
+    ).toMatchObject({
+      href: "https://github.com/Cla-Code-Community/candidate",
+      target: "_blank",
+      rel: "noopener noreferrer",
+    });
   });
 });

--- a/frontend/tests/unit/components/JobsFiltersCard.test.tsx
+++ b/frontend/tests/unit/components/JobsFiltersCard.test.tsx
@@ -47,6 +47,19 @@ describe("JobsFiltersCard", () => {
     expect(screen.getByPlaceholderText(/buscar/i)).toHaveValue("");
   });
 
+  it("limita a busca e trunca filtros longos sem perder o conteúdo completo", () => {
+    const longFilter = "a".repeat(100);
+    renderFiltersCard({ keywordFilter: [longFilter] });
+
+    expect(screen.getByPlaceholderText(/buscar/i)).toHaveAttribute(
+      "maxlength",
+      "100",
+    );
+    const filterText = screen.getByText(longFilter);
+    expect(filterText).toHaveClass("truncate");
+    expect(filterText.closest("[title]")).toHaveAttribute("title", longFilter);
+  });
+
   it("renderiza total e area de filtros", () => {
     renderFiltersCard();
 

--- a/frontend/tests/unit/components/KeywordsModal.test.tsx
+++ b/frontend/tests/unit/components/KeywordsModal.test.tsx
@@ -27,7 +27,9 @@ describe("KeywordsModal", () => {
   it("adiciona uma nova keyword localmente", async () => {
     render(<KeywordsModal onClose={vi.fn()} />);
 
-    await waitFor(() => expect(screen.queryByText(/carregando/i)).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText(/carregando/i)).not.toBeInTheDocument(),
+    );
 
     const input = screen.getByPlaceholderText(/nova keyword/i);
     const addButton = screen.getByRole("button", { name: /adicionar/i });
@@ -39,17 +41,29 @@ describe("KeywordsModal", () => {
     expect(input).toHaveValue("");
   });
 
+  it("limita novas keywords e preserva o texto completo no title", async () => {
+    mocks.fetchKeywordsMock.mockResolvedValueOnce(["a".repeat(100)]);
+    render(<KeywordsModal onClose={vi.fn()} />);
+
+    const input = screen.getByPlaceholderText(/nova keyword/i);
+    expect(input).toHaveAttribute("maxlength", "100");
+
+    const keyword = await screen.findByText("a".repeat(100));
+    expect(keyword).toHaveClass("truncate");
+    expect(keyword.closest("[title]")).toHaveAttribute(
+      "title",
+      "a".repeat(100),
+    );
+  });
+
   it("remove uma keyword localmente", async () => {
     render(<KeywordsModal onClose={vi.fn()} />);
 
     await waitFor(() => expect(screen.getByText("react")).toBeInTheDocument());
 
-    const reactBadge = screen.getByText("react");
-    const removeButton = reactBadge.querySelector("button");
-    
-    if (removeButton) {
-      fireEvent.click(removeButton);
-    }
+    fireEvent.click(
+      screen.getByRole("button", { name: /remover keyword react/i }),
+    );
 
     expect(screen.queryByText("react")).not.toBeInTheDocument();
   });
@@ -60,7 +74,9 @@ describe("KeywordsModal", () => {
 
     await waitFor(() => expect(screen.getByText("react")).toBeInTheDocument());
 
-    const saveButton = screen.getByRole("button", { name: /salvar alterações/i });
+    const saveButton = screen.getByRole("button", {
+      name: /salvar alterações/i,
+    });
     fireEvent.click(saveButton);
 
     await waitFor(() => {
@@ -73,7 +89,9 @@ describe("KeywordsModal", () => {
     const onClose = vi.fn();
     render(<KeywordsModal onClose={onClose} />);
 
-    await waitFor(() => expect(screen.queryByText(/carregando/i)).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText(/carregando/i)).not.toBeInTheDocument(),
+    );
 
     const cancelButton = screen.getByRole("button", { name: /cancelar/i });
     fireEvent.click(cancelButton);

--- a/frontend/tests/unit/components/landing/TeamSection.test.tsx
+++ b/frontend/tests/unit/components/landing/TeamSection.test.tsx
@@ -4,7 +4,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("swiper/react", () => ({
   Swiper: ({ children }: any) => <div data-testid="swiper">{children}</div>,
-  SwiperSlide: ({ children }: any) => <div data-testid="swiper-slide">{children}</div>,
+  SwiperSlide: ({ children }: any) => (
+    <div data-testid="swiper-slide">{children}</div>
+  ),
 }));
 
 vi.mock("swiper/modules", () => ({
@@ -51,8 +53,8 @@ describe("TeamSection", () => {
     expect(screen.queryByText("bot-user")).not.toBeInTheDocument();
 
     // membros fixos
-    expect(screen.getByText("PedroLucas1337")).toBeInTheDocument();
-    expect(screen.getByText("thalitat")).toBeInTheDocument();
+    expect(screen.getByText("@PedroLucas1337")).toBeInTheDocument();
+    expect(screen.getByText("@thalitat")).toBeInTheDocument();
 
     expect(screen.getByText("QA")).toBeInTheDocument();
     expect(screen.getByText("UX/UI Designer")).toBeInTheDocument();
@@ -105,7 +107,7 @@ describe("TeamSection", () => {
       const pedroImg = screen.getByAltText("PedroLucas1337");
       expect(pedroImg).toHaveAttribute(
         "src",
-        "https://github.com/PedroLucas1337.png"
+        "https://github.com/PedroLucas1337.png",
       );
     });
   });
@@ -120,8 +122,8 @@ describe("TeamSection", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Benevanio")).toBeInTheDocument();
-      expect(screen.getByText("PedroLucas1337")).toBeInTheDocument();
-      expect(screen.getByText("thalitat")).toBeInTheDocument();
+      expect(screen.getByText("@PedroLucas1337")).toBeInTheDocument();
+      expect(screen.getByText("@thalitat")).toBeInTheDocument();
     });
   });
 
@@ -169,6 +171,36 @@ describe("TeamSection", () => {
     });
   });
 
+  it("exibe nome e username obtidos do perfil do GitHub", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+      if (String(url).includes("/contributors")) {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              id: 6,
+              login: "hltav",
+              avatar_url: "https://github.com/hltav.png",
+              html_url: "https://github.com/hltav",
+              contributions: 3,
+              type: "User",
+            },
+          ],
+        } as any;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({ name: "Henrique Tavarez" }),
+      } as any;
+    });
+
+    render(<TeamSection />);
+
+    expect(await screen.findByText("Henrique Tavarez")).toBeInTheDocument();
+    expect(screen.getByText("@hltav")).toBeInTheDocument();
+  });
+
   it("nao atualiza contributors quando lista vazia", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue({
       ok: true,
@@ -179,8 +211,8 @@ describe("TeamSection", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Benevanio")).toBeInTheDocument();
-      expect(screen.getByText("PedroLucas1337")).toBeInTheDocument();
-      expect(screen.getByText("thalitat")).toBeInTheDocument();
+      expect(screen.getByText("@PedroLucas1337")).toBeInTheDocument();
+      expect(screen.getByText("@thalitat")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/tests/unit/components/landing/TeamSection.test.tsx
+++ b/frontend/tests/unit/components/landing/TeamSection.test.tsx
@@ -201,6 +201,22 @@ describe("TeamSection", () => {
     expect(screen.getByText("@hltav")).toBeInTheDocument();
   });
 
+  it("padroniza função e quantidade de commits em todos os cards", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    } as any);
+
+    render(<TeamSection />);
+
+    expect(
+      await screen.findByText("Founder & Backend Dev"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("188 commits")).toBeInTheDocument();
+    expect(screen.getByText("QA")).toBeInTheDocument();
+    expect(screen.queryByText("0 commits")).not.toBeInTheDocument();
+  });
+
   it("nao atualiza contributors quando lista vazia", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue({
       ok: true,

--- a/frontend/tests/unit/components/login/RegisterSide.test.tsx
+++ b/frontend/tests/unit/components/login/RegisterSide.test.tsx
@@ -19,7 +19,7 @@ function fillRequiredRegisterFields() {
     target: { value: "+5534999999999" },
   });
   fireEvent.change(screen.getByLabelText(/senha/i), {
-    target: { value: "123456" },
+    target: { value: "12345678" },
   });
   fireEvent.change(screen.getByLabelText(/nível de experiência/i), {
     target: { value: "pleno" },
@@ -40,18 +40,27 @@ vi.mock("@unpic/react", () => ({
 vi.mock("framer-motion", () => ({
   motion: {
     div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-    button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+    button: ({ children, ...props }: any) => (
+      <button {...props}>{children}</button>
+    ),
   },
 }));
 
 vi.mock("react-phone-number-input", () => ({
-  default: ({ value, onChange, placeholder, disabled }: any) => (
+  default: ({
+    value,
+    onChange,
+    placeholder,
+    disabled,
+    numberInputProps,
+  }: any) => (
     <input
       type="tel"
       value={value || ""}
       onChange={(e) => onChange(e.target.value)}
       placeholder={placeholder}
       disabled={disabled}
+      {...numberInputProps}
     />
   ),
 }));
@@ -94,24 +103,71 @@ describe("RegisterSide", () => {
     expect(screen.getByLabelText(/senha/i)).toHaveAttribute("type", "text");
   });
 
+  it("limita os campos de cadastro conforme as regras da API", () => {
+    render(<RegisterSide />);
+
+    expect(screen.getByLabelText(/nome/i)).toHaveAttribute("maxlength", "100");
+    expect(screen.getByLabelText(/email/i)).toHaveAttribute("maxlength", "254");
+    expect(screen.getByPlaceholderText(/\(34\)/i)).toHaveAttribute(
+      "maxlength",
+      "16",
+    );
+    expect(screen.getByLabelText(/senha/i)).toHaveAttribute("maxlength", "128");
+    expect(screen.getByLabelText(/cpf/i)).toHaveAttribute("maxlength", "14");
+  });
+
+  it("exige senha com pelo menos oito caracteres", async () => {
+    render(<RegisterSide />);
+    fillRequiredRegisterFields();
+    fireEvent.change(screen.getByLabelText(/senha/i), {
+      target: { value: "1234567" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /cadastrar/i }));
+
+    expect(
+      await screen.findByText(/pelo menos 8 caracteres/i),
+    ).toBeInTheDocument();
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
   it("mostra erros obrigatórios ao submeter vazio", async () => {
     render(<RegisterSide />);
     fireEvent.click(screen.getByRole("button", { name: /cadastrar/i }));
-    expect(await screen.findByText(/campo de nome é obrigatório/i)).toBeInTheDocument();
-    expect(await screen.findByText(/campo de e-mail é obrigatório/i)).toBeInTheDocument();
-    expect(await screen.findByText(/campo de telefone é obrigatório/i)).toBeInTheDocument();
-    expect(await screen.findByText(/campo de senha é obrigatório/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/campo de nome é obrigatório/i),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText(/campo de e-mail é obrigatório/i),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText(/campo de telefone é obrigatório/i),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText(/campo de senha é obrigatório/i),
+    ).toBeInTheDocument();
     expect(await screen.findByText(/selecione seu nível/i)).toBeInTheDocument();
   });
 
   it("valida CPF inválido quando preenchido", async () => {
     render(<RegisterSide />);
-    fireEvent.change(screen.getByLabelText(/nome/i), { target: { value: "Usuário" } });
-    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: "teste@email.com" } });
-    fireEvent.change(screen.getByPlaceholderText(/\(34\)/i), { target: { value: "+5534999999999" } });
-    fireEvent.change(screen.getByLabelText(/senha/i), { target: { value: "123456" } });
-    fireEvent.change(screen.getByLabelText(/nível de experiência/i), { target: { value: "pleno" } });
-    fireEvent.change(screen.getByLabelText(/cpf/i), { target: { value: "123" } });
+    fireEvent.change(screen.getByLabelText(/nome/i), {
+      target: { value: "Usuário" },
+    });
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "teste@email.com" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/\(34\)/i), {
+      target: { value: "+5534999999999" },
+    });
+    fireEvent.change(screen.getByLabelText(/senha/i), {
+      target: { value: "12345678" },
+    });
+    fireEvent.change(screen.getByLabelText(/nível de experiência/i), {
+      target: { value: "pleno" },
+    });
+    fireEvent.change(screen.getByLabelText(/cpf/i), {
+      target: { value: "123" },
+    });
     fireEvent.click(screen.getByRole("button", { name: /cadastrar/i }));
     expect(await screen.findByText(/cpf inválido/i)).toBeInTheDocument();
   });
@@ -124,7 +180,7 @@ describe("RegisterSide", () => {
     await waitFor(() => {
       expect(mockRegister).toHaveBeenCalledWith({
         email: "bene@teste.com",
-        password: "123456",
+        password: "12345678",
         name: "Bene",
         phone: "+5534999999999",
         cpf: undefined,
@@ -138,12 +194,14 @@ describe("RegisterSide", () => {
     mockRegister.mockResolvedValueOnce({ message: "Usuário criado" });
     render(<RegisterSide />);
     fillRequiredRegisterFields();
-    fireEvent.change(screen.getByLabelText(/cpf/i), { target: { value: "12345678901" } });
+    fireEvent.change(screen.getByLabelText(/cpf/i), {
+      target: { value: "12345678901" },
+    });
     fireEvent.click(screen.getByRole("button", { name: /cadastrar/i }));
     await waitFor(() => {
       expect(mockRegister).toHaveBeenCalledWith({
         email: "bene@teste.com",
-        password: "123456",
+        password: "12345678",
         name: "Bene",
         phone: "+5534999999999",
         cpf: "123.456.789-01",
@@ -165,7 +223,9 @@ describe("RegisterSide", () => {
     render(<RegisterSide />);
     fillRequiredRegisterFields();
     fireEvent.click(screen.getByRole("button", { name: /cadastrar/i }));
-    expect(await screen.findByRole("button", { name: /cadastrando\.\.\./i })).toBeDisabled();
+    expect(
+      await screen.findByRole("button", { name: /cadastrando\.\.\./i }),
+    ).toBeDisabled();
   });
 
   it("formata CPF corretamente", () => {
@@ -188,7 +248,7 @@ describe("RegisterSide", () => {
     fireEvent.change(nomeInput, { target: { value: "Bene" } });
     fireEvent.change(emailInput, { target: { value: "bene@teste.com" } });
     fireEvent.change(telefoneInput, { target: { value: "+5534999999999" } });
-    fireEvent.change(passwordInput, { target: { value: "123456" } });
+    fireEvent.change(passwordInput, { target: { value: "12345678" } });
     fireEvent.change(levelInput, { target: { value: "pleno" } });
     fireEvent.click(screen.getByRole("button", { name: /cadastrar/i }));
     await waitFor(() => {
@@ -202,30 +262,36 @@ describe("RegisterSide", () => {
 
   it("redireciona para GitHub OAuth ao clicar no botao GitHub", async () => {
     mockGetGithubAuthUrl.mockResolvedValueOnce(
-      "https://github.com/login/oauth/authorize?state=abc"
+      "https://github.com/login/oauth/authorize?state=abc",
     );
 
     render(<RegisterSide />);
 
     const buttons = screen.getAllByRole("button");
-    const githubButton = buttons.find(btn => btn.querySelector('svg.fill-gray-900'));
+    const githubButton = buttons.find((btn) =>
+      btn.querySelector("svg.fill-gray-900"),
+    );
     fireEvent.click(githubButton!);
 
     await waitFor(() => {
       expect(mockGetGithubAuthUrl).toHaveBeenCalled();
       expect(window.location.href).toBe(
-        "https://github.com/login/oauth/authorize?state=abc"
+        "https://github.com/login/oauth/authorize?state=abc",
       );
     });
   });
 
   it("exibe erro quando GitHub OAuth falha", async () => {
-    mockGetGithubAuthUrl.mockRejectedValueOnce(new Error("Github indisponível"));
+    mockGetGithubAuthUrl.mockRejectedValueOnce(
+      new Error("Github indisponível"),
+    );
 
     render(<RegisterSide />);
 
     const buttons = screen.getAllByRole("button");
-    const githubButton = buttons.find(btn => btn.querySelector('svg.fill-gray-900'));
+    const githubButton = buttons.find((btn) =>
+      btn.querySelector("svg.fill-gray-900"),
+    );
     fireEvent.click(githubButton!);
 
     expect(await screen.findByText(/Github indisponível/i)).toBeInTheDocument();
@@ -233,7 +299,7 @@ describe("RegisterSide", () => {
 
   it("redireciona para LinkedIn OAuth ao clicar no botao LinkedIn", async () => {
     mockGetLinkedinAuthUrl.mockResolvedValueOnce(
-      "https://www.linkedin.com/oauth/v2/authorization?state=abc"
+      "https://www.linkedin.com/oauth/v2/authorization?state=abc",
     );
 
     render(<RegisterSide />);
@@ -244,7 +310,7 @@ describe("RegisterSide", () => {
     await waitFor(() => {
       expect(mockGetLinkedinAuthUrl).toHaveBeenCalled();
       expect(window.location.href).toBe(
-        "https://www.linkedin.com/oauth/v2/authorization?state=abc"
+        "https://www.linkedin.com/oauth/v2/authorization?state=abc",
       );
     });
   });

--- a/frontend/tests/unit/new_dashboard/jobs.test.tsx
+++ b/frontend/tests/unit/new_dashboard/jobs.test.tsx
@@ -77,6 +77,7 @@ describe("new_dashboard job components", () => {
     );
     const filterGrid = searchInput.closest("label")?.parentElement;
 
+    expect(searchInput).toHaveAttribute("maxlength", "100");
     expect(filterGrid).toHaveClass(
       "grid-cols-1",
       "sm:grid-cols-2",
@@ -87,12 +88,9 @@ describe("new_dashboard job components", () => {
       expect(select).toHaveClass("w-full", "min-w-0");
     });
 
-    fireEvent.change(
-      searchInput,
-      {
-        target: { value: "react" },
-      },
-    );
+    fireEvent.change(searchInput, {
+      target: { value: "react" },
+    });
     fireEvent.change(screen.getAllByRole("combobox")[0], {
       target: { value: "Remoto" },
     });
@@ -119,11 +117,7 @@ describe("new_dashboard job components", () => {
 
   it("renderiza a tabela vazia e paginação local e remota", () => {
     const localRender = render(
-      <JobTable
-        jobs={[]}
-        onOpenJob={vi.fn()}
-        onStatusChange={vi.fn()}
-      />,
+      <JobTable jobs={[]} onOpenJob={vi.fn()} onStatusChange={vi.fn()} />,
     );
 
     expect(screen.getByText(/nenhuma vaga encontrada/i)).toBeInTheDocument();
@@ -180,7 +174,9 @@ describe("new_dashboard job components", () => {
     const onOpen = vi.fn();
     const onStatusChange = vi.fn();
 
-    render(<JobRow job={baseJob} onOpen={onOpen} onStatusChange={onStatusChange} />);
+    render(
+      <JobRow job={baseJob} onOpen={onOpen} onStatusChange={onStatusChange} />,
+    );
 
     fireEvent.click(screen.getAllByRole("button", { name: /detalhes/i })[0]);
     fireEvent.click(screen.getByRole("button", { name: /salvar/i }));
@@ -222,11 +218,7 @@ describe("new_dashboard job components", () => {
     ];
 
     render(
-      <JobTable
-        jobs={jobs}
-        onOpenJob={vi.fn()}
-        onStatusChange={vi.fn()}
-      />,
+      <JobTable jobs={jobs} onOpenJob={vi.fn()} onStatusChange={vi.fn()} />,
     );
 
     const visibleTitles = () =>
@@ -371,9 +363,12 @@ describe("new_dashboard job components", () => {
     fireEvent.change(screen.getByPlaceholderText(/r\$ 8.000 - r\$ 10.000/i), {
       target: { value: "€ 4.000" },
     });
-    fireEvent.change(screen.getByPlaceholderText(/react, typescript, node.js/i), {
-      target: { value: "NestJS, PostgreSQL" },
-    });
+    fireEvent.change(
+      screen.getByPlaceholderText(/react, typescript, node.js/i),
+      {
+        target: { value: "NestJS, PostgreSQL" },
+      },
+    );
     fireEvent.change(screen.getByPlaceholderText(/linkedin, gupy/i), {
       target: { value: "Gupy" },
     });
@@ -407,8 +402,7 @@ describe("new_dashboard job components", () => {
 
     function Harness() {
       const [searchQuery, setSearchQuery] = useState("");
-      const [filterType, setFilterType] =
-        useState<JobModelFilter>("Todos");
+      const [filterType, setFilterType] = useState<JobModelFilter>("Todos");
       const [filterLevel, setFilterLevel] = useState("Todos");
       const [continentFilter, setContinentFilter] =
         useState<ContinentFilter>("Todos");


### PR DESCRIPTION
## Descrição

Esta PR corrige problemas de validação nos formulários e filtros, além de melhorar a apresentação dos contribuidores na página inicial.

## Alterações

### Cadastro

- [PAV-82 — Campos do formulário de cadastro não possuem limite de caracteres](https://linear.app/tatame/issue/PAV-82/bug009-campos-do-formulario-de-cadastro-nao-possuem-limite-de)
  - Nome limitado a 100 caracteres.
  - E-mail limitado a 254 caracteres.
  - Telefone limitado a 15 dígitos.
  - Senha limitada a 128 caracteres.
  - Senha mínima alterada para 8 caracteres.
  - Validações equivalentes adicionadas ao backend.
  - Testes para entradas acima dos limites.

### Filtros

- [PAV-79 — Campo de filtro não possui limite de caracteres](https://linear.app/tatame/issue/PAV-79/bug007-campo-de-filtro-nao-possui-limite-de-caracteres)
  - Buscas e novas keywords limitadas a 100 caracteres.
  - Filtros longos truncados visualmente.
  - Conteúdo completo disponível pelo atributo `title`.
  - Prevenção de quebra horizontal do layout.
  - Cobertura para dashboard, vagas e gerenciamento de filtros.

### Página inicial

- [PAV-103 — Ícone do GitHub não redireciona para o repositório](https://linear.app/tatame/issue/PAV-103/bug-011-icone-do-github-nao-redireciona-para-o-repositorio-do-projeto)
  - Link corrigido para o repositório oficial.
  - Adicionado nome acessível ao ícone.
  - Teste de regressão para URL, abertura em nova aba e segurança.

- [PAV-102 — Exibir nome do colaborador em vez do username](https://linear.app/tatame/issue/PAV-102/melhoria-002-exibir-nome-do-colaborador-em-vez-do-username-do-github)
  - Exibição do nome do colaborador.
  - Username preservado no formato `@username`.
  - Consulta ao perfil do GitHub para obter nomes não cadastrados localmente.
  - Fallback mantido quando a API estiver indisponível.

- [PAV-101 — Padronizar informações nos cards dos contribuidores](https://linear.app/tatame/issue/PAV-101/melhoria-001-padronizar-as-informacoes-exibidas-nos-cards-dos)
  - Cards padronizados com nome, username, função e commits.
  - Dados retornados pela API têm prioridade sobre o fallback local.
  - Contagens iguais a zero ficam ocultas.
  - Espaçamento preservado para manter o alinhamento dos cards.

## Validações

- ✅ 316 testes do frontend passando.
- ✅ 523 testes do backend passando.
- ✅ Build de produção concluído.
- ✅ ESLint sem erros.

## Commits

- `64fa516` — Limites e validações do cadastro.
- `64ebdca` — Limites e truncamento dos filtros.
- `99b7a30` — Redirecionamento do ícone do GitHub.
- `05fe1bb` — Nome e username dos contribuidores.
- `98bf63e` — Padronização dos cards.