### PR TITLE
[PAV-128] [Build] Corrigir package-lock.json e restaurar npm ci

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2059,13 +2059,11 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2230,13 +2228,11 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2469,13 +2465,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10315,13 +10309,11 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10333,13 +10325,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10351,13 +10341,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10369,13 +10357,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10387,13 +10373,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10405,13 +10389,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10423,13 +10405,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10441,13 +10421,11 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10459,13 +10437,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10477,13 +10453,11 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10495,13 +10469,11 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10513,13 +10485,11 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10531,13 +10501,11 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10549,13 +10517,11 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10567,13 +10533,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10585,13 +10549,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10603,13 +10565,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10621,13 +10581,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10639,13 +10597,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10657,13 +10613,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10675,13 +10629,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10693,13 +10645,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10711,13 +10661,11 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13182,7 +13130,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13203,7 +13150,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13224,7 +13170,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13245,7 +13190,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13266,7 +13210,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13287,7 +13230,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13308,7 +13250,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13329,7 +13270,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13350,7 +13290,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13371,7 +13310,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13392,7 +13330,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -18850,6 +18787,22 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "18.0.0",


### PR DESCRIPTION
## Contexto

O `package-lock.json` estava dessincronizado dos manifests do monorepo. Em ambientes baseados em `node:24-alpine`, o `npm ci` falhava com:

```text
Missing: yaml@2.9.0 from lock file
```

A dependência `yaml@2.9.0` é requerida de forma transitiva e opcional pelo `lint-staged@17.0.8`, mas sua entrada raiz estava ausente no lockfile.

## Alteração

* Regenerado o `package-lock.json` com Node 24 e npm 11.
* Adicionada corretamente a resolução de `yaml@2.9.0`.
* Normalizados metadados de dependências opcionais de plataforma.
* Preservadas as versões declaradas nos manifests.
* Nenhum `package.json` foi alterado.
* Nenhuma dependência foi atualizada de forma indiscriminada.
* Nenhuma alteração funcional foi introduzida.

O diff está restrito a:

```text
package-lock.json | 79 alterações
16 inserções
63 remoções
```

## Validações

### Reprodutibilidade

* `npm ci` executado duas vezes em ambiente limpo com `node:24-alpine`.
* O hash do lockfile permaneceu estável após as duas instalações.
* `npm ci` também validado com Node 22 e npm 10, utilizados pelo CI.
* `yaml@2.9.0` foi resolvido corretamente.
* O `npm ci` não produziu novas alterações no lockfile.

### Testes e builds

* Backend: 60 arquivos e 569 testes aprovados.
* Frontend: testes aprovados.
* Frontend: lint aprovado sem erros e com warnings preexistentes.
* Frontend: build aprovado.
* Front Admin: 36 arquivos e 107 testes aprovados.
* Front Admin: build aprovado.
* Scraper Go: testes aprovados.

### Docker

Foram construídas com sucesso as imagens:

* `migrate`
* `backend`
* `frontend`
* `front_admin`

A stack integrada foi iniciada e validada:

* PostgreSQL saudável.
* Valkey saudável.
* Migration concluída com código de saída zero.
* Backend saudável em `http://localhost:3001/health`.
* Frontend disponível.
* Front Admin disponível.
* Painel administrativo de observabilidade funcional.

Também foi realizada uma coleta controlada para validar a PAV-118:

* Limite de aproximadamente 1,5 CPU aplicado ao scraper.
* Memória permaneceu abaixo do limite de 2 GiB.
* Nenhum reinício do scraper ou backend.
* Nenhum panic, fatal, timeout ou OOM identificado.
* 862 adapters concluídos e 8 falhas relacionadas a providers externos.
* Backend permaneceu saudável após a parada controlada do scraper.
* O painel identificou corretamente o scraper como indisponível após a parada.

## Limitações conhecidas

O lint do `front_admin` ainda possui quatro erros preexistentes e não relacionados ao lockfile. Seus testes e build foram aprovados. Esses erros não foram corrigidos para preservar o escopo restrito desta entrega.

O CI utiliza Node 22, enquanto os Dockerfiles utilizam `node:24-alpine`. O lockfile foi validado nas duas versões, mas o alinhamento e a fixação das versões de Node e npm serão tratados separadamente na evolução do CI/CD.

## Checklist

* [x] Lockfile regenerado no ambiente oficial.
* [x] Nenhuma edição manual do lockfile.
* [x] `yaml@2.9.0` corretamente resolvido.
* [x] `npm ci` funciona em Linux/Alpine.
* [x] Duas instalações limpas produziram o mesmo resultado.
* [x] `npm ci` não modifica o lockfile.
* [x] Builds Docker aprovados.
* [x] Testes dos workspaces aprovados.
* [x] Diff restrito ao `package-lock.json`.
* [x] Nenhuma atualização ampla de dependências.
* [x] Nenhuma alteração funcional.

Fixes PAV-128
