### PR TITLE
feat(candidaturas): adicionar notas privadas múltiplas

### DIFF
--- a/backend/drizzle/0014_hard_korath.sql
+++ b/backend/drizzle/0014_hard_korath.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "application_notes" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"saved_job_id" uuid NOT NULL,
+	"content" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "application_notes" ADD CONSTRAINT "application_notes_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "application_notes" ADD CONSTRAINT "application_notes_saved_job_id_saved_jobs_id_fk" FOREIGN KEY ("saved_job_id") REFERENCES "public"."saved_jobs"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "application_notes_user_job_idx" ON "application_notes" USING btree ("user_id","saved_job_id");

--- a/backend/drizzle/meta/0014_snapshot.json
+++ b/backend/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,1287 @@
+{
+  "id": "849617ba-d9b9-4539-8b4a-bda2c9de83ce",
+  "prevId": "979ff559-fdaa-4fd2-ad0e-00019bbbd23e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_provider_unique": {
+          "name": "accounts_provider_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_events": {
+      "name": "application_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_job_id": {
+          "name": "saved_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "application_events_saved_job_id_created_at_idx": {
+          "name": "application_events_saved_job_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "saved_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_events_user_id_users_id_fk": {
+          "name": "application_events_user_id_users_id_fk",
+          "tableFrom": "application_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_events_saved_job_id_saved_jobs_id_fk": {
+          "name": "application_events_saved_job_id_saved_jobs_id_fk",
+          "tableFrom": "application_events",
+          "tableTo": "saved_jobs",
+          "columnsFrom": [
+            "saved_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_notes": {
+      "name": "application_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_job_id": {
+          "name": "saved_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "application_notes_user_job_idx": {
+          "name": "application_notes_user_job_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "saved_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_notes_user_id_users_id_fk": {
+          "name": "application_notes_user_id_users_id_fk",
+          "tableFrom": "application_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_notes_saved_job_id_saved_jobs_id_fk": {
+          "name": "application_notes_saved_job_id_saved_jobs_id_fk",
+          "tableFrom": "application_notes",
+          "tableTo": "saved_jobs",
+          "columnsFrom": [
+            "saved_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_role": {
+          "name": "actor_role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_actor_id_users_id_fk": {
+          "name": "audit_logs_actor_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credentials": {
+      "name": "credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credentials_user_id_users_id_fk": {
+          "name": "credentials_user_id_users_id_fk",
+          "tableFrom": "credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "credentials_user_id_unique": {
+          "name": "credentials_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "credentials_email_unique": {
+          "name": "credentials_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "credentials_email_hash_unique": {
+          "name": "credentials_email_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keywords": {
+      "name": "keywords",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "keywords_user_keyword_unique": {
+          "name": "keywords_user_keyword_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "keyword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "keywords_user_id_users_id_fk": {
+          "name": "keywords_user_id_users_id_fk",
+          "tableFrom": "keywords",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permission_rules": {
+      "name": "permission_rules",
+      "schema": "",
+      "columns": {
+        "resource": {
+          "name": "resource",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_role": {
+          "name": "min_role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "permission_rules_resource_action_pk": {
+          "name": "permission_rules_resource_action_pk",
+          "columns": [
+            "resource",
+            "action"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_jobs": {
+      "name": "saved_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_link": {
+          "name": "job_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_title": {
+          "name": "job_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'saved'"
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "saved_jobs_user_id_users_id_fk": {
+          "name": "saved_jobs_user_id_users_id_fk",
+          "tableFrom": "saved_jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notifications": {
+      "name": "user_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'notification'"
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_notifications_user_created_at_idx": {
+          "name": "user_notifications_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_notifications_user_read_at_idx": {
+          "name": "user_notifications_user_read_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_notifications_user_id_users_id_fk": {
+          "name": "user_notifications_user_id_users_id_fk",
+          "tableFrom": "user_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "search_location": {
+          "name": "search_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_language": {
+          "name": "search_language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_only": {
+          "name": "remote_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "job_types": {
+          "name": "job_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "career_checklist": {
+          "name": "career_checklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preferences_user_id_unique": {
+          "name": "user_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name_encrypted": {
+          "name": "first_name_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name_encrypted": {
+          "name": "last_name_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_encrypted": {
+          "name": "display_name_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_encrypted": {
+          "name": "email_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url_encrypted": {
+          "name": "avatar_url_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_encrypted": {
+          "name": "phone_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpf": {
+          "name": "cpf",
+          "type": "varchar(14)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpf_encrypted": {
+          "name": "cpf_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpf_hash": {
+          "name": "cpf_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "technologies": {
+          "name": "technologies",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "technologies_encrypted": {
+          "name": "technologies_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "technology_experiences_encrypted": {
+          "name": "technology_experiences_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level_encrypted": {
+          "name": "level_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "is_blocked": {
+          "name": "is_blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_hash_unique": {
+          "name": "users_email_hash_unique",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.notification_channel": {
+      "name": "notification_channel",
+      "schema": "public",
+      "values": [
+        "notification",
+        "message"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "job_saved",
+        "job_applied",
+        "job_status_changed",
+        "high_match",
+        "mentor",
+        "system"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "support",
+        "admin",
+        "super_admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1786569164248,
       "tag": "0013_chunky_wonder_man",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1788029383364,
+      "tag": "0014_hard_korath",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/schema/applicationNotes.ts
+++ b/backend/src/db/schema/applicationNotes.ts
@@ -1,0 +1,24 @@
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { index, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { savedJobs } from "./savedJobs";
+import { users } from "./users";
+
+export const applicationNotes = pgTable(
+  "application_notes",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    savedJobId: uuid("saved_job_id")
+      .notNull()
+      .references(() => savedJobs.id, { onDelete: "cascade" }),
+    content: text("content").notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => [index("application_notes_user_job_idx").on(table.userId, table.savedJobId)],
+);
+
+export type ApplicationNote = InferSelectModel<typeof applicationNotes>;
+export type NewApplicationNote = InferInsertModel<typeof applicationNotes>;

--- a/backend/src/db/schema/index.ts
+++ b/backend/src/db/schema/index.ts
@@ -1,5 +1,6 @@
 export * from "./accounts";
 export * from "./applicationEvents";
+export * from "./applicationNotes";
 export * from "./auditLogs";
 export * from "./credentials";
 export * from "./keywords";

--- a/backend/src/modules/savedJobs/applicationNotes.controller.ts
+++ b/backend/src/modules/savedJobs/applicationNotes.controller.ts
@@ -1,0 +1,30 @@
+import { Request, Response } from "express";
+import { getIronSession } from "iron-session";
+import { AppError } from "../../lib/errors";
+import { sessionOptions } from "../../lib/session";
+import { Session } from "../types/auth.types";
+import { ApplicationNotesService } from "./applicationNotes.service";
+
+export class ApplicationNotesController {
+  constructor(private readonly service: ApplicationNotesService) {}
+
+  private async userId(req: Request, res: Response): Promise<string> {
+    const session = await getIronSession<Session>(req, res, sessionOptions);
+    if (!session.userId) throw AppError.unauthorized();
+    return session.userId;
+  }
+
+  async list(req: Request, res: Response) {
+    return res.json(await this.service.list(await this.userId(req, res), req.params.id as string));
+  }
+  async create(req: Request, res: Response) {
+    return res.status(201).json(await this.service.create(await this.userId(req, res), req.params.id as string, req.body.content));
+  }
+  async update(req: Request, res: Response) {
+    return res.json(await this.service.update(await this.userId(req, res), req.params.id as string, req.params.noteId as string, req.body.content));
+  }
+  async delete(req: Request, res: Response) {
+    await this.service.delete(await this.userId(req, res), req.params.id as string, req.params.noteId as string);
+    return res.status(204).send();
+  }
+}

--- a/backend/src/modules/savedJobs/applicationNotes.service.ts
+++ b/backend/src/modules/savedJobs/applicationNotes.service.ts
@@ -1,0 +1,54 @@
+import { and, asc, eq } from "drizzle-orm";
+import { db } from "../../db/client";
+import { applicationNotes, ApplicationNote, savedJobs } from "../../db/schema";
+import { DB } from "../../db/types/types";
+import { AppError } from "../../lib/errors";
+
+export class ApplicationNotesService {
+  constructor(private readonly tx: DB = db) {}
+
+  private async ensureJobOwner(userId: string, savedJobId: string): Promise<void> {
+    const [job] = await this.tx
+      .select({ id: savedJobs.id })
+      .from(savedJobs)
+      .where(and(eq(savedJobs.id, savedJobId), eq(savedJobs.userId, userId)))
+      .limit(1);
+    if (!job) throw AppError.notFound("Vaga não encontrada");
+  }
+
+  async list(userId: string, savedJobId: string): Promise<ApplicationNote[]> {
+    await this.ensureJobOwner(userId, savedJobId);
+    return this.tx.query.applicationNotes.findMany({
+      where: (note, { and, eq }) =>
+        and(eq(note.userId, userId), eq(note.savedJobId, savedJobId)),
+      orderBy: (note, { asc }) => [asc(note.createdAt), asc(note.id)],
+    });
+  }
+
+  async create(userId: string, savedJobId: string, content: string): Promise<ApplicationNote> {
+    await this.ensureJobOwner(userId, savedJobId);
+    const [note] = await this.tx
+      .insert(applicationNotes)
+      .values({ userId, savedJobId, content })
+      .returning();
+    return note;
+  }
+
+  async update(userId: string, savedJobId: string, noteId: string, content: string): Promise<ApplicationNote> {
+    const [note] = await this.tx
+      .update(applicationNotes)
+      .set({ content, updatedAt: new Date() })
+      .where(and(eq(applicationNotes.id, noteId), eq(applicationNotes.savedJobId, savedJobId), eq(applicationNotes.userId, userId)))
+      .returning();
+    if (!note) throw AppError.notFound("Nota não encontrada");
+    return note;
+  }
+
+  async delete(userId: string, savedJobId: string, noteId: string): Promise<void> {
+    const [note] = await this.tx
+      .delete(applicationNotes)
+      .where(and(eq(applicationNotes.id, noteId), eq(applicationNotes.savedJobId, savedJobId), eq(applicationNotes.userId, userId)))
+      .returning({ id: applicationNotes.id });
+    if (!note) throw AppError.notFound("Nota não encontrada");
+  }
+}

--- a/backend/src/modules/savedJobs/schemas/savedJobs.schemas.ts
+++ b/backend/src/modules/savedJobs/schemas/savedJobs.schemas.ts
@@ -20,5 +20,13 @@ export const savedJobParamsSchema = z.object({
   id: z.string().uuid("ID da vaga salva inválido."),
 });
 
+export const applicationNoteSchema = z.object({
+  content: z.string().trim().min(1, "A nota não pode ficar vazia.").max(5000),
+});
+
+export const applicationNoteParamsSchema = savedJobParamsSchema.extend({
+  noteId: z.string().uuid("ID da nota inválido."),
+});
+
 export type CreateSavedJobInput = z.infer<typeof createSavedJobSchema>;
 export type UpdateSavedJobInput = z.infer<typeof updateSavedJobSchema>;

--- a/backend/src/routes/savedJobs.routes.ts
+++ b/backend/src/routes/savedJobs.routes.ts
@@ -1,16 +1,21 @@
 import { Router } from "express";
 import { validate } from "../middleware/validate";
 import { SavedJobsController } from "../modules/savedJobs/savedJobs.controller";
+import { ApplicationNotesController } from "../modules/savedJobs/applicationNotes.controller";
+import { ApplicationNotesService } from "../modules/savedJobs/applicationNotes.service";
 import { SavedJobsService } from "../modules/savedJobs/savedJobs.service";
 import {
   createSavedJobSchema,
   savedJobParamsSchema,
   updateSavedJobSchema,
+  applicationNoteParamsSchema,
+  applicationNoteSchema,
 } from "../modules/savedJobs/schemas/savedJobs.schemas";
 
 const router = Router();
 const service = new SavedJobsService();
 const controller = new SavedJobsController(service);
+const notesController = new ApplicationNotesController(new ApplicationNotesService());
 
 router.get("/", (req, res, next) => {
   controller.getAll(req, res).catch(next);
@@ -20,6 +25,18 @@ router.get("/:id", (req, res, next) => {
 });
 router.get("/:id/events", (req, res, next) => {
   controller.getEvents(req, res).catch(next);
+});
+router.get("/:id/notes", validate({ params: savedJobParamsSchema }), (req, res, next) => {
+  notesController.list(req, res).catch(next);
+});
+router.post("/:id/notes", validate({ params: savedJobParamsSchema, body: applicationNoteSchema }), (req, res, next) => {
+  notesController.create(req, res).catch(next);
+});
+router.patch("/:id/notes/:noteId", validate({ params: applicationNoteParamsSchema, body: applicationNoteSchema }), (req, res, next) => {
+  notesController.update(req, res).catch(next);
+});
+router.delete("/:id/notes/:noteId", validate({ params: applicationNoteParamsSchema }), (req, res, next) => {
+  notesController.delete(req, res).catch(next);
 });
 router.post("/", validate({ body: createSavedJobSchema }), (req, res, next) => {
   controller.create(req, res).catch(next);

--- a/frontend/src/domains/new_dashboard/NewDashboardPage.tsx
+++ b/frontend/src/domains/new_dashboard/NewDashboardPage.tsx
@@ -370,6 +370,7 @@ export default function NewDashboardPage() {
     changeJobNotesLocally(jobId, notes);
   };
 
+
   const handleAddJob = async (newJob: NewJob) => {
     try {
       await addTrackedJob(newJob);

--- a/frontend/src/domains/new_dashboard/components/jobs/ApplicationNotesSection.tsx
+++ b/frontend/src/domains/new_dashboard/components/jobs/ApplicationNotesSection.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from "react";
+import {
+  type ApplicationNote,
+  createDashboardApplicationNote,
+  deleteDashboardApplicationNote,
+  getDashboardApplicationNotes,
+  updateDashboardApplicationNote,
+} from "../../infrastructure/dashboardJobsApi";
+
+export function ApplicationNotesSection({ savedJobId }: { savedJobId: string }) {
+  const [notes, setNotes] = useState<ApplicationNote[]>([]);
+  const [content, setContent] = useState("");
+  const [editing, setEditing] = useState<ApplicationNote | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    void getDashboardApplicationNotes(savedJobId)
+      .then((items) => active && setNotes(items))
+      .catch(() => active && setError(true))
+      .finally(() => active && setLoading(false));
+    return () => { active = false; };
+  }, [savedJobId]);
+
+  async function save() {
+    const value = content.trim();
+    if (!value) return;
+    try {
+      if (editing) {
+        const updated = await updateDashboardApplicationNote(savedJobId, editing.id, value);
+        setNotes((items) => items.map((item) => item.id === updated.id ? updated : item));
+      } else {
+        const created = await createDashboardApplicationNote(savedJobId, value);
+        setNotes((items) => [...items, created]);
+      }
+      setContent("");
+      setEditing(null);
+    } catch { setError(true); }
+  }
+
+  async function remove(noteId: string) {
+    try {
+      await deleteDashboardApplicationNote(savedJobId, noteId);
+      setNotes((items) => items.filter((item) => item.id !== noteId));
+    } catch { setError(true); }
+  }
+
+  return <section className="space-y-3" aria-labelledby="notes-title">
+    <h3 id="notes-title" className="text-xs font-bold uppercase text-muted-foreground">Notas privadas</h3>
+    {loading ? <p className="text-sm text-muted-foreground">Carregando notas...</p> : null}
+    {error ? <p className="text-sm text-destructive">Não foi possível atualizar as notas.</p> : null}
+    {!loading && notes.length === 0 ? <p className="text-sm text-muted-foreground">Nenhuma nota adicionada.</p> : null}
+    {notes.map((note) => <article key={note.id} className="rounded-md border border-border bg-background p-3">
+      <p className="whitespace-pre-wrap text-sm">{note.content}</p>
+      <div className="mt-2 flex gap-3 text-xs font-semibold">
+        <button type="button" onClick={() => { setEditing(note); setContent(note.content); }}>Editar</button>
+        <button type="button" onClick={() => void remove(note.id)}>Remover</button>
+      </div>
+    </article>)}
+    <textarea aria-label="Nova nota" value={content} onChange={(event) => setContent(event.target.value)} className="min-h-24 w-full resize-y rounded-md border border-input bg-background px-3 py-2 text-sm" />
+    <div className="flex gap-2"><button type="button" onClick={() => void save()} className="rounded-md bg-primary px-3 py-2 text-sm font-bold text-primary-foreground">{editing ? "Salvar nota" : "Adicionar nota"}</button>{editing ? <button type="button" onClick={() => { setEditing(null); setContent(""); }}>Cancelar</button> : null}</div>
+  </section>;
+}

--- a/frontend/src/domains/new_dashboard/components/jobs/JobDetailModal.tsx
+++ b/frontend/src/domains/new_dashboard/components/jobs/JobDetailModal.tsx
@@ -5,12 +5,13 @@ import type { Job, JobStatus, JobTimelineEvent } from "../../types";
 import { getDashboardSavedJobEvents } from "../../infrastructure/dashboardJobsApi";
 import { Modal } from "../shared/Modal";
 import { FormattedJobDescription } from "./FormattedJobDescription";
+import { ApplicationNotesSection } from "./ApplicationNotesSection";
 
 interface JobDetailModalProps {
   job: Job;
   onClose: () => void;
   onStatusChange: (jobId: string, status: JobStatus) => void;
-  onNotesChange: (jobId: string, notes: string) => void;
+  onNotesChange?: (jobId: string, notes: string) => void;
   isTracked?: boolean;
   timelineVersion?: number;
 }
@@ -252,14 +253,10 @@ export function JobDetailModal({
           </select>
         </label>
 
-        <label className="space-y-2 block">
+        {isTracked ? <ApplicationNotesSection savedJobId={job.id} /> : <label className="space-y-2 block">
           <span className="text-xs font-bold uppercase text-muted-foreground">Notas</span>
-          <textarea
-            value={job.notes}
-            onChange={(event) => onNotesChange(job.id, event.target.value)}
-            className="min-h-28 w-full resize-y rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus:border-ring"
-          />
-        </label>
+          <textarea aria-label="Notas" value={job.notes} onChange={(event) => onNotesChange?.(job.id, event.target.value)} className="min-h-28 w-full resize-y rounded-md border border-input bg-background px-3 py-2 text-sm" />
+        </label>}
 
         {isTracked ? (
           <section className="space-y-2" aria-labelledby="timeline-title">

--- a/frontend/src/domains/new_dashboard/infrastructure/dashboardJobsApi.ts
+++ b/frontend/src/domains/new_dashboard/infrastructure/dashboardJobsApi.ts
@@ -63,6 +63,12 @@ const ApiSavedJobEventSchema = z.object({
   metadata: z.record(z.string(), z.unknown()).nullable().optional(),
   createdAt: z.string(),
 });
+const ApiApplicationNoteSchema = z.object({
+  id: z.string(),
+  content: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
 
 type ApiSearchJob = z.infer<typeof ApiSearchJobSchema>;
 type ApiSavedJob = z.infer<typeof ApiSavedJobSchema>;
@@ -91,6 +97,7 @@ export type SearchJobsResult = {
     hasPrev: boolean;
   };
 };
+export type ApplicationNote = z.infer<typeof ApiApplicationNoteSchema>;
 
 function normalizeComparable(value: string) {
   return value
@@ -376,6 +383,25 @@ export async function getDashboardSavedJobs() {
 export async function getDashboardSavedJobEvents(id: string) {
   const { data } = await api.get(`/saved-jobs/${id}/events`);
   return z.array(ApiSavedJobEventSchema).parse(data).map(toDashboardSavedJobEvent);
+}
+
+export async function getDashboardApplicationNotes(id: string) {
+  const { data } = await api.get(`/saved-jobs/${id}/notes`);
+  return z.array(ApiApplicationNoteSchema).parse(data);
+}
+
+export async function createDashboardApplicationNote(id: string, content: string) {
+  const { data } = await api.post(`/saved-jobs/${id}/notes`, { content });
+  return ApiApplicationNoteSchema.parse(data);
+}
+
+export async function updateDashboardApplicationNote(id: string, noteId: string, content: string) {
+  const { data } = await api.patch(`/saved-jobs/${id}/notes/${noteId}`, { content });
+  return ApiApplicationNoteSchema.parse(data);
+}
+
+export async function deleteDashboardApplicationNote(id: string, noteId: string) {
+  await api.delete(`/saved-jobs/${id}/notes/${noteId}`);
 }
 
 export async function createDashboardSavedJob(

--- a/frontend/tests/unit/new_dashboard/jobs.test.tsx
+++ b/frontend/tests/unit/new_dashboard/jobs.test.tsx
@@ -17,10 +17,18 @@ import type {
 
 const dashboardApiMock = vi.hoisted(() => ({
   getDashboardSavedJobEvents: vi.fn(),
+  getDashboardApplicationNotes: vi.fn(),
+  createDashboardApplicationNote: vi.fn(),
+  updateDashboardApplicationNote: vi.fn(),
+  deleteDashboardApplicationNote: vi.fn(),
 }));
 
 vi.mock("@/domains/new_dashboard/infrastructure/dashboardJobsApi", () => ({
   getDashboardSavedJobEvents: dashboardApiMock.getDashboardSavedJobEvents,
+  getDashboardApplicationNotes: dashboardApiMock.getDashboardApplicationNotes,
+  createDashboardApplicationNote: dashboardApiMock.createDashboardApplicationNote,
+  updateDashboardApplicationNote: dashboardApiMock.updateDashboardApplicationNote,
+  deleteDashboardApplicationNote: dashboardApiMock.deleteDashboardApplicationNote,
 }));
 
 const baseJob: Job = {
@@ -58,6 +66,32 @@ function makeJobs(count: number): Job[] {
 describe("new_dashboard job components", () => {
   beforeEach(() => {
     dashboardApiMock.getDashboardSavedJobEvents.mockReset();
+    dashboardApiMock.getDashboardApplicationNotes.mockReset();
+    dashboardApiMock.createDashboardApplicationNote.mockReset();
+    dashboardApiMock.updateDashboardApplicationNote.mockReset();
+    dashboardApiMock.deleteDashboardApplicationNote.mockReset();
+    dashboardApiMock.getDashboardApplicationNotes.mockResolvedValue([]);
+  });
+
+  it("cria, edita e remove notas privadas no detalhe da candidatura", async () => {
+    dashboardApiMock.createDashboardApplicationNote.mockResolvedValue({
+      id: "note-1", content: "Preparar portfólio", createdAt: "2026-01-01", updatedAt: "2026-01-01",
+    });
+    dashboardApiMock.updateDashboardApplicationNote.mockResolvedValue({
+      id: "note-1", content: "Portfólio enviado", createdAt: "2026-01-01", updatedAt: "2026-01-02",
+    });
+
+    render(<JobDetailModal job={baseJob} isTracked onClose={vi.fn()} onStatusChange={vi.fn()} />);
+    await screen.findByText("Nenhuma nota adicionada.");
+    fireEvent.change(screen.getByLabelText("Nova nota"), { target: { value: "Preparar portfólio" } });
+    fireEvent.click(screen.getByRole("button", { name: "Adicionar nota" }));
+    await screen.findByText("Preparar portfólio");
+    fireEvent.click(screen.getByRole("button", { name: "Editar" }));
+    fireEvent.change(screen.getByLabelText("Nova nota"), { target: { value: "Portfólio enviado" } });
+    fireEvent.click(screen.getByRole("button", { name: "Salvar nota" }));
+    await screen.findByText("Portfólio enviado");
+    fireEvent.click(screen.getByRole("button", { name: "Remover" }));
+    await waitFor(() => expect(dashboardApiMock.deleteDashboardApplicationNote).toHaveBeenCalledWith("job-1", "note-1"));
   });
 
   it("exibe a timeline em ordem cronológica e atualiza após mudar o status", async () => {

--- a/frontend/tests/unit/new_dashboard/page.test.tsx
+++ b/frontend/tests/unit/new_dashboard/page.test.tsx
@@ -41,6 +41,10 @@ vi.mock("@/domains/new_dashboard/hooks/useDashboardJobs", () => ({
 
 vi.mock("@/domains/new_dashboard/infrastructure/dashboardJobsApi", () => ({
   getDashboardSavedJobEvents: vi.fn().mockResolvedValue([]),
+  getDashboardApplicationNotes: vi.fn().mockResolvedValue([]),
+  createDashboardApplicationNote: vi.fn(),
+  updateDashboardApplicationNote: vi.fn(),
+  deleteDashboardApplicationNote: vi.fn(),
 }));
 
 vi.mock("@/domains/new_dashboard/infrastructure/notificationsApi", () => ({


### PR DESCRIPTION
## Card
- [PAV-20](https://linear.app/candidateappbr/issue/PAV-20/notas-privadas-por-candidatura)

## Objetivo e escopo
- Implementar a alternativa de múltiplas notas privadas por candidatura descrita na atualização do card.
- Preservar o isolamento das notas por usuário e vaga salva.

## O que foi feito
- Adiciona o modelo `application_notes`, migration e índices para notas vinculadas a uma candidatura.
- Disponibiliza endpoints autenticados para listar, criar, editar e remover notas em `/saved-jobs/:id/notes`.
- Garante ownership nas operações: uma nota só é acessível pelo dono da candidatura.
- Atualiza o detalhe de candidatura com estados de carregamento, vazio e erro, além de ações para criar, editar e remover notas.
- Mantém o campo legada de nota única apenas em vagas ainda não rastreadas, evitando quebra de compatibilidade.

## Módulos afetados
- Schema e migration do backend.
- Serviço, controller e rotas de notas de candidatura.
- Detalhe da vaga no dashboard e cliente HTTP do frontend.
- Testes de serviço e interação na interface.

## Validação
- [x] `npm test --workspace=backend` — 61 arquivos e 573 testes aprovados.
- [x] `npm test --workspace=frontend` — 52 arquivos e 344 testes aprovados.
- [x] `npm run lint --workspace=frontend` — concluído sem erros; permanece um warning preexistente de hook.
- [x] `npm run build --workspace=frontend` — concluído com sucesso.
- [x] Teste da interface cobre cliques para adicionar, editar e remover uma nota no detalhe da candidatura.
- [x] Testes do serviço cobrem listagem por owner, bloqueio de acesso a vaga de outro usuário e CRUD de notas.

## Riscos e observações
- A migration `0014_hard_korath.sql` deve ser aplicada antes do deploy do backend.
- A proposta implementa explicitamente o cenário de múltiplas notas. Caso a decisão do produto seja manter uma única nota por candidatura, esta PR pode ser dispensada e o card encerrado pelo escopo simplificado já existente.