### PR TITLE
[PAV-133] Corrigir tipagem em autenticação e conexões

### DIFF
--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -69,7 +69,7 @@ export class AuthService {
     try {
       await emailService.sendWelcome({
         email: user.email,
-        name: user.displayName ?? user.username,
+        name: user.displayName ?? user.username ?? "Usuário",
       });
     } catch (error) {
       logError("Falha ao disparar e-mail de boas-vindas no login social.", {

--- a/backend/src/modules/auth/connections.controller.ts
+++ b/backend/src/modules/auth/connections.controller.ts
@@ -18,7 +18,10 @@ export class ConnectionsController {
     const userId = req.session.userId as string;
     const provider = req.params.provider;
 
-    if (!(SUPPORTED_PROVIDERS as readonly string[]).includes(provider)) {
+    if (
+      typeof provider !== "string" ||
+      !(SUPPORTED_PROVIDERS as readonly string[]).includes(provider)
+    ) {
       throw AppError.validation("Provider inválido.");
     }
 

--- a/backend/src/modules/auth/credentials.service.ts
+++ b/backend/src/modules/auth/credentials.service.ts
@@ -86,8 +86,8 @@ export class CredentialsService {
     // E-mail de boas-vindas: falha nunca derruba o registro (EMAIL-08).
     try {
       await emailService.sendWelcome({
-        email: user.email,
-        name: user.displayName ?? user.username,
+        email: normalizedEmail,
+        name: name?.trim() || normalizedEmail.split("@")[0],
       });
     } catch (error) {
       logError("Falha ao disparar e-mail de boas-vindas.", {

--- a/backend/tests/integration/routes/connections.routes.test.ts
+++ b/backend/tests/integration/routes/connections.routes.test.ts
@@ -84,4 +84,20 @@ describe("connections routes", () => {
     expect(res.body.code).toBe("VALIDATION_ERROR");
     expect(mocks.disconnectProvider).not.toHaveBeenCalled();
   });
+
+  it("recusa provider não escalar antes de desconectar", async () => {
+    const controller = new ConnectionsController();
+
+    await expect(
+      controller.disconnect(
+        {
+          session: { userId: "user-A" },
+          params: { provider: ["google", "github"] },
+        } as any,
+        { json: vi.fn() } as any,
+      ),
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+
+    expect(mocks.disconnectProvider).not.toHaveBeenCalled();
+  });
 });

--- a/backend/tests/unit/modules/auth/auth.service.test.ts
+++ b/backend/tests/unit/modules/auth/auth.service.test.ts
@@ -216,5 +216,20 @@ describe("AuthService", () => {
         profile: mockProfile,
       });
     });
+
+    it("uses a fallback name when the social profile has no name", async () => {
+      mocks.exchangeCode.mockResolvedValueOnce(mockProfile);
+      mocks.findOrCreateUser.mockResolvedValueOnce({
+        user: { ...mockUser, displayName: null, username: null },
+        isNewUser: true,
+      });
+
+      await service.handleCallback(validCallbackParams);
+
+      expect(mocks.sendWelcome).toHaveBeenCalledWith({
+        email: mockUser.email,
+        name: "Usuário",
+      });
+    });
   });
 });

--- a/backend/tests/unit/modules/auth/credentials.service.test.ts
+++ b/backend/tests/unit/modules/auth/credentials.service.test.ts
@@ -213,8 +213,8 @@ describe("CredentialsService", () => {
       await service.register(registerInput);
 
       expect(mocks.sendWelcome).toHaveBeenCalledWith({
-        email: mockUser.email,
-        name: mockUser.displayName,
+        email: registerInput.email,
+        name: registerInput.name,
       });
     });
 


### PR DESCRIPTION
## Linear

Issue: PAV-133

## Branch flow

- [x] Este PR é um fix destinado a `develop`.
- [x] Este PR não contém alteração direta ou fluxo indevido para `master`.
- [x] A branch foi criada a partir da base prevista pelo fluxo do projeto.

## Objetivo

Corrigir erros de TypeScript nos fluxos de boas-vindas e desconexão de provedores, preservando o comportamento das rotas e evitando coerções de tipo inseguras.

## Escopo

O que faz parte desta entrega:

- Garantia de valores `string` no envio de e-mail de boas-vindas.
- Fallback de nome para perfil OAuth sem nome ou username.
- Uso dos valores validados no cadastro por credenciais.
- Validação de `req.params.provider` como valor escalar antes da lista de providers e da desconexão.
- Testes de regressão para os cenários corrigidos.

O que está fora do escopo:

- Alterar templates ou provider de e-mail.
- Alterar banco, migrations ou contratos HTTP.

## Resumo das alterações

- O OAuth usa `Usuário` como fallback de nome quando os dois campos opcionais não existem.
- O cadastro usa o e-mail normalizado e o nome validado — ou o prefixo do e-mail — para o e-mail de boas-vindas.
- A rota de conexões recusa `provider` em formato não escalar antes de chamar o serviço.
- Adicionados testes de fallback de nome e provider inválido em array.

## Como testar

```bash
npm exec --workspace=backend tsc -- --noEmit -p tsconfig.json
npm test --workspace=backend
```

## Validation

- [x] Checagem de tipos do backend executada sem erros.
- [x] Testes relevantes executados.
- [x] Suíte completa do backend executada: 60 arquivos e 572 testes aprovados.
- [x] Validação manual não aplicável: a mudança é interna ao backend e está coberta por testes unitários e de rota.

## Impacto de banco / migration

- [x] Não altera schema nem migrations.

## Impacto em contratos/API

- [x] Não altera endpoint, payload, schema ou comportamento público de API.

## Impacto de configuração / infraestrutura

- [x] Não altera configuração, env, Docker, filas, cache, serviços ou infraestrutura.

## Impacto de segurança

- [x] Sem impacto relevante.

## Impacto de dados pessoais / privacidade

- [x] Sem tratamento novo ou alteração de dados pessoais.

## Compatibilidade / dependências

- [x] Não depende de outra task/PR.

## Riscos

Baixo. O fallback impede que dados nulos cheguem ao template de e-mail, e a nova validação apenas rejeita formatos que a rota não suporta.

## Rollback

Reverter este commit restaura o comportamento anterior sem migração nem alteração de dados.

## Checklist final

- [x] Escopo limitado ao card.
- [x] Não inclui segredos, `.env`, certificados ou tokens.
- [x] Não inclui arquivos temporários, builds, caches ou artefatos desnecessários.
- [x] Não executa deploy como efeito desta PR.
- [x] Critérios de aceite do card foram conferidos individualmente.