### PR TITLE
PAV-34: Hardening de segurança (rate limit, CORS, headers)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,14 @@ ENCRYPTION_KEY_ID=default
 SEARCH_KEY=
 
 # CORS / frontend access
+# Fonte da verdade das origens permitidas. Em produção, se vazio, cai apenas
+# nas origens *.candidate.app.br (localhost nunca entra por fallback).
 CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:5174
+
+# Rate limit de autenticação (login e cadastro). Variável ausente usa o default.
+AUTH_RATE_LIMIT_IP_MAX=20
+AUTH_RATE_LIMIT_ACCOUNT_MAX=5
+AUTH_RATE_LIMIT_WINDOW_SECONDS=900
 
 # Search filters
 SEARCH_LOCATION=Brasil

--- a/BACKEND.md
+++ b/BACKEND.md
@@ -141,8 +141,10 @@ await emailService.sendWelcome({ email: "usuario@exemplo.com", name: "Ana" });
 
 - `withSession` — integra `iron-session` (sessões + cookie `vagas_session`).
 - `requireAuth` — valida autenticação nas rotas que exigem usuário.
-- `securityHeaders` — cabeçalhos de segurança.
+- `securityHeaders` — cabeçalhos de segurança (ver seção **Segurança e criptografia**).
 - `cors` — configuração de CORS (opções em `src/middleware/cors.ts`).
+- `rateLimit` — limitadores de tentativas em endpoints de autenticação (`src/middleware/rateLimit.ts`).
+- `validate` — validação/normalização de `body`/`query`/`params` via schemas Zod.
 - `requestId` — correlação de requisições.
 - `metrics` — coleta de métricas Prometheus.
 - `errorHandler` — tratamento centralizado de erros.
@@ -244,10 +246,54 @@ Definidas/consumidas em `src/config.ts` e outros módulos:
 
 ## Segurança e criptografia
 
+### Autenticação e sessão
+
 - Senhas armazenadas usando Argon2 (`argon2`), com opções configuradas no serviço de credenciais.
-- Cookies de sessão `httpOnly` e `secure` quando NODE_ENV=production.
+- Cookies de sessão `httpOnly` e `secure` quando `NODE_ENV=production`.
+- Campos sensíveis de perfil usam criptografia (`ENCRYPTION_MASTER_KEY`) e hashes pesquisáveis (`SEARCH_KEY`) onde aplicável.
+
+### Rate limiting (`src/middleware/rateLimit.ts`)
+
+Limitadores por janela deslizante, com contador no Valkey quando `VALKEY_URL` está definido e fallback em memória caso contrário. Respostas incluem `RateLimit-Limit`/`RateLimit-Remaining`/`RateLimit-Reset`; ao estourar, `429` com `Retry-After`. Falha do backend de contagem responde `503` (fail-closed).
+
+| Rota | Limitadores | Chave |
+| --- | --- | --- |
+| `POST /auth/login` | `authIpRateLimiter`, `authAccountRateLimiter` | IP (hash) / e-mail (hash) |
+| `POST /auth/register` | `authIpRateLimiter`, `authRegisterRateLimiter` | IP (hash) / e-mail (hash), bucket próprio |
+
+Configuração (variável ausente usa o default; valor `≤ 0` ou não numérico também cai no default):
+
+- `AUTH_RATE_LIMIT_IP_MAX` — máximo de tentativas por IP na janela. Default `20`.
+- `AUTH_RATE_LIMIT_ACCOUNT_MAX` — máximo por e-mail na janela (login e cadastro têm buckets separados). Default `5`.
+- `AUTH_RATE_LIMIT_WINDOW_SECONDS` — tamanho da janela em segundos. Default `900` (15 min).
+
+Pendente: aplicar rate limit ao endpoint de exportação de dados (LGPD) quando a PAV-41 for mergeada.
+
+### CORS (`src/middleware/cors.ts`)
+
+- `CORS_ALLOWED_ORIGINS` (lista separada por vírgula) é a fonte da verdade das origens permitidas.
+- Sem a env: em `production` cai apenas nas origens de produção (`*.candidate.app.br`) e loga um aviso — `localhost` **nunca** entra no allowlist de produção por fallback. Fora de produção, o fallback inclui `http://localhost:5173` e `:5174`.
+- `credentials: true`; métodos `GET, POST, PATCH, DELETE, OPTIONS`; headers `Content-Type, Authorization, X-Requested-With`; preflight cacheado por 24 h. Requisições sem header `Origin` (server-to-server, mesma origem) são permitidas.
+- Origem fora do allowlist retorna `403` com `{ code: "FORBIDDEN", message: "Origem não permitida." }`.
+
+### Cabeçalhos de resposta (`src/middleware/securityHeaders.ts`)
+
+Aplicados a todas as respostas:
+
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY`
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- `Permissions-Policy: camera=(), microphone=(), geolocation=()`
+- `Strict-Transport-Security: max-age=31536000; includeSubDomains` — só sobre HTTPS (`req.secure`, resolvido via `trust proxy`) ou `NODE_ENV=production`. `preload` fica de fora de propósito (opt-in do time).
+- `x-powered-by` desabilitado.
+- CSP é tratada separadamente na PAV-132.
+
+### Entrada e persistência
+
+- Corpo de requisição limitado a `16kb` (`express.json({ limit: "16kb" })`).
+- Validação/normalização de entrada via schemas Zod (`middleware/validate`) nas rotas de auth, users, keywords e saved-jobs.
+- Acesso ao banco via Drizzle (queries parametrizadas — sem concatenação de SQL).
 - Índices únicos e constraints no DB (ex: email/username/keyword uniques) definidos nas tabelas Drizzle.
-- Campos sensíveis de perfil usam criptografia e hashes pesquisáveis onde aplicável.
 
 ## Integração com serviço Go
 

--- a/backend/src/middleware/cors.ts
+++ b/backend/src/middleware/cors.ts
@@ -1,20 +1,41 @@
 import cors from "cors";
+import { logWarn } from "../logger";
 
-const DEFAULT_ALLOWED_ORIGINS = [
+const PROD_ALLOWED_ORIGINS = [
   "https://candidate.app.br",
   "https://admin.candidate.app.br",
   "https://support.candidate.app.br",
   "https://api.candidate.app.br",
+];
+
+const DEV_ALLOWED_ORIGINS = [
   "http://localhost:5173",
   "http://localhost:5174",
 ];
 
+/**
+ * Origens permitidas. `CORS_ALLOWED_ORIGINS` (lista separada por vírgula) é a
+ * fonte da verdade. Sem a env:
+ * - em `production`: cai só nas origens de produção e loga um aviso — o
+ *   `localhost` nunca entra no allowlist de produção por fallback silencioso;
+ * - fora de produção: prod + `localhost` (dev e admin locais).
+ */
 function parseAllowedOrigins(value: string | undefined): Set<string> {
   const configured = String(value ?? "")
     .split(",")
     .map((o) => o.trim())
     .filter(Boolean);
-  return new Set(configured.length > 0 ? configured : DEFAULT_ALLOWED_ORIGINS);
+
+  if (configured.length > 0) return new Set(configured);
+
+  if (process.env.NODE_ENV === "production") {
+    logWarn(
+      "CORS_ALLOWED_ORIGINS não definida em produção; usando apenas as origens de produção padrão.",
+    );
+    return new Set(PROD_ALLOWED_ORIGINS);
+  }
+
+  return new Set([...PROD_ALLOWED_ORIGINS, ...DEV_ALLOWED_ORIGINS]);
 }
 
 export const corsOptions: cors.CorsOptions = {

--- a/backend/src/middleware/rateLimit.ts
+++ b/backend/src/middleware/rateLimit.ts
@@ -152,6 +152,18 @@ export const authAccountRateLimiter = createRateLimiter({
   keyGenerator: normalizedEmail,
 });
 
+/**
+ * Limita o cadastro por e-mail (bucket próprio, separado do de login) para
+ * conter criação de contas em massa e enumeração de e-mails já registrados.
+ * Sem e-mail no corpo o limiter é ignorado e a validação Zod trata o 400.
+ */
+export const authRegisterRateLimiter = createRateLimiter({
+  name: "auth:register",
+  max: authAccountMax,
+  windowSeconds: authWindowSeconds,
+  keyGenerator: normalizedEmail,
+});
+
 export function resetInMemoryRateLimitStore(): void {
   memoryStore.clear();
 }

--- a/backend/src/middleware/securityHeaders.ts
+++ b/backend/src/middleware/securityHeaders.ts
@@ -1,7 +1,18 @@
 import { NextFunction, Request, Response } from "express";
 
+/**
+ * Cabeçalhos de segurança aplicados a todas as respostas.
+ *
+ * `Strict-Transport-Security` só é enviado sobre HTTPS (atrás do proxy,
+ * `req.secure` reflete `x-forwarded-proto` graças a `app.set("trust proxy", 1)`)
+ * ou quando `NODE_ENV=production`, onde o tráfego é sempre HTTPS. `preload`
+ * fica de fora de propósito: entrar na lista de preload é uma decisão difícil
+ * de reverter e deve ser um opt-in explícito do time.
+ *
+ * CSP não é definida aqui — é tratada na PAV-132.
+ */
 export function securityHeaders(
-  _req: Request,
+  req: Request,
   res: Response,
   next: NextFunction,
 ): void {
@@ -12,5 +23,13 @@ export function securityHeaders(
     "Permissions-Policy",
     "camera=(), microphone=(), geolocation=()",
   );
+
+  if (req.secure || process.env.NODE_ENV === "production") {
+    res.setHeader(
+      "Strict-Transport-Security",
+      "max-age=31536000; includeSubDomains",
+    );
+  }
+
   next();
 }

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import {
     authAccountRateLimiter,
     authIpRateLimiter,
+    authRegisterRateLimiter,
 } from "../middleware/rateLimit";
 import { requireAuth } from "../middleware/requireAuth";
 import { validate } from "../middleware/validate";
@@ -52,6 +53,8 @@ router.delete("/connections/:provider", requireAuth, (req, res, next) => {
 // Credentials
 router.post(
   "/register",
+  authIpRateLimiter,
+  authRegisterRateLimiter,
   validate({ body: RegisterSchema }),
   (req, res, next) => {
     credentialsController.register(req, res).catch(next);

--- a/backend/tests/integration/routes/auth.routes.test.ts
+++ b/backend/tests/integration/routes/auth.routes.test.ts
@@ -435,6 +435,31 @@ describe("Integration - Auth Routes", () => {
         .send(registerPayload)
         .expect(500);
     });
+
+    it("bloqueia cadastros repetidos para o mesmo email com 429", async () => {
+      vi.mocked(getIronSession).mockResolvedValue(
+        fixtureCredentialsSession as any,
+      );
+
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        await request(app)
+          .post(`${BASE}/register`)
+          .send(registerPayload)
+          .expect(201);
+      }
+
+      const res = await request(app)
+        .post(`${BASE}/register`)
+        .send(registerPayload)
+        .expect(429);
+
+      expect(res.body).toHaveProperty(
+        "error",
+        "Muitas tentativas. Tente novamente mais tarde.",
+      );
+      expect(res.headers["retry-after"]).toBeDefined();
+      expect(mockCredentialsService.register).toHaveBeenCalledTimes(5);
+    });
   });
 
   // ── POST /login ───────────────────────────────────────────────────────────

--- a/backend/tests/unit/app.test.ts
+++ b/backend/tests/unit/app.test.ts
@@ -232,6 +232,60 @@ describe("jobsApiApp", () => {
     expect(res.headers["referrer-policy"]).toBe(
       "strict-origin-when-cross-origin",
     );
+    expect(res.headers["permissions-policy"]).toBe(
+      "camera=(), microphone=(), geolocation=()",
+    );
+  });
+
+  it("não envia HSTS sobre HTTP fora de produção", async () => {
+    const app = createJobsApiApp();
+    const res = await request(app).get("/health").expect(200);
+
+    expect(res.headers["strict-transport-security"]).toBeUndefined();
+  });
+
+  it("envia HSTS quando NODE_ENV=production", async () => {
+    const previous = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      const app = createJobsApiApp();
+      const res = await request(app).get("/health").expect(200);
+
+      expect(res.headers["strict-transport-security"]).toBe(
+        "max-age=31536000; includeSubDomains",
+      );
+    } finally {
+      process.env.NODE_ENV = previous;
+    }
+  });
+
+  it("em produção sem CORS_ALLOWED_ORIGINS bloqueia localhost mas libera origem de produção", async () => {
+    const previousEnv = process.env.NODE_ENV;
+    const previousOrigins = process.env.CORS_ALLOWED_ORIGINS;
+    process.env.NODE_ENV = "production";
+    delete process.env.CORS_ALLOWED_ORIGINS;
+    try {
+      const app = createJobsApiApp();
+
+      await request(app)
+        .get("/health")
+        .set("Origin", "https://candidate.app.br")
+        .expect(200);
+
+      const blocked = await request(app)
+        .get("/health")
+        .set("Origin", "http://localhost:5173")
+        .expect(403);
+
+      expect(blocked.body.message).toBe("Origem não permitida.");
+    } finally {
+      process.env.NODE_ENV = previousEnv;
+      if (previousOrigins === undefined) {
+        delete process.env.CORS_ALLOWED_ORIGINS;
+      } else {
+        process.env.CORS_ALLOWED_ORIGINS = previousOrigins;
+      }
+    }
   });
 
   // ── jobs/search ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Descrição

Hardening de segurança da PAV-34, sobre o que já existia na `develop`. Levantamento completo do estado atual no comentário do card. Este PR fecha as lacunas independentes:

1. **Rate limit em `POST /auth/register`** — os limiters já existiam mas eram aplicados só no `POST /auth/login`. Agora o cadastro usa `authIpRateLimiter` (por IP) + um novo `authRegisterRateLimiter` (por e-mail, bucket próprio, separado do de login) para conter criação de contas em massa e enumeração de e-mails.
2. **HSTS** — `securityHeaders` passa a enviar `Strict-Transport-Security: max-age=31536000; includeSubDomains` sobre HTTPS (`req.secure`, resolvido via `trust proxy`) ou `NODE_ENV=production`. `preload` fica de fora de propósito — entrar na lista de preload é decisão difícil de reverter e deve ser opt-in do time.
3. **CORS fail-safe em produção** — sem `CORS_ALLOWED_ORIGINS`, em `production` o fallback cai só nas origens `*.candidate.app.br` e loga um aviso; `localhost` nunca entra no allowlist de produção por fallback silencioso. Fora de produção o comportamento não muda.
4. **Documentação** — seção Segurança do `BACKEND.md` reescrita (rate limiting com limites/env vars/cobertura, CORS, cabeçalhos completos, limites de entrada) + `AUTH_RATE_LIMIT_*` adicionadas ao `.env.example` da raiz. Fecha a AC "configurações de segurança ficam documentadas".

### Fora do escopo (com nota)

- **Rate limit no endpoint de exportação (LGPD)** — o endpoint não existe na `develop`, está na PAV-41 (#240, em review). É follow-up de 2 linhas quando aquela mergear (ou vai no próprio PAV-41).
- **CSP / stored-XSS / sanitização de output** — é a PAV-132.
- **Rate limiter global em todos os endpoints** — o card pede "endpoints sensíveis", não compensa o risco de quebrar o dashboard.

## Linear link

https://linear.app/candidateappbr/issue/PAV-34/hardening-de-seguranca-rate-limit-cors-headers-lgpd-basica

## Como foi testado

**Automatizado** — `npm run test --workspace=backend`: 574/574 (+4 novos). Cobrem: HSTS presente com `NODE_ENV=production` e ausente sobre HTTP fora de produção; CORS em produção sem env bloqueia `localhost` e libera `candidate.app.br`; `POST /auth/register` retorna `429` com `Retry-After` após 5 tentativas para o mesmo e-mail.

**Manual (stack local)** — headers em `GET /health`: `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy`, `Permissions-Policy` presentes; HSTS ausente (dev/http, correto). `POST /auth/register` 6× para o mesmo e-mail: `201` → `409` × 4 → **`429`**.

**Checklist (LOCAL_DEVELOPMENT.md §14):** instala do zero, app sobe, `/health` responde, testes do escopo passando, sem erro de TS no escopo, validado manualmente, sem regressão, logs limpos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
